### PR TITLE
Revert "us-east-1 provider only in module"

### DIFF
--- a/examples/default/ca.tf
+++ b/examples/default/ca.tf
@@ -1,3 +1,14 @@
 module "certificate_authority" {
   source = "../../"
+  # source  = "serverless-ca/terraform-aws-ca"
+  # version = "1.0.0"
+
+  # cert_info_files     = ["tls", "revoked", "revoked-root-ca"]
+  # issuing_ca_info     = local.issuing_ca_info
+  # root_ca_info        = local.root_ca_info
+
+  providers = {
+    aws           = aws
+    aws.us-east-1 = aws.us-east-1 # required even if CloudFront not used
+  }
 }

--- a/examples/default/provider.tf
+++ b/examples/default/provider.tf
@@ -1,3 +1,9 @@
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias      = "us-east-1"
+  region     = "us-east-1"
+  sts_region = "eu-west-2"
+}

--- a/examples/rsa-public-crl/ca.tf
+++ b/examples/rsa-public-crl/ca.tf
@@ -1,5 +1,7 @@
 module "certificate_authority" {
   source = "../../"
+  # source  = "serverless-ca/terraform-aws-ca"
+  # version = "1.0.0"
 
   bucket_prefix       = "my-company"
   env                 = "prod"
@@ -11,4 +13,9 @@ module "certificate_authority" {
   root_ca_key_spec    = "RSA_4096"
   public_crl          = true
   cert_info_files     = ["tls", "revoked", "revoked-root-ca"]
+
+  providers = {
+    aws           = aws
+    aws.us-east-1 = aws.us-east-1 # certificates for CloudFront must be in this region
+  }
 }

--- a/examples/rsa-public-crl/provider.tf
+++ b/examples/rsa-public-crl/provider.tf
@@ -1,3 +1,9 @@
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias      = "us-east-1"
+  region     = "us-east-1"
+  sts_region = "eu-west-2"
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,13 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.0"
+      source                = "hashicorp/aws"
+      version               = ">= 5.0"
+      configuration_aliases = [aws, aws.us-east-1]
     }
   }
-}
-
-provider "aws" {
-  alias  = "us-east-1"
-  region = "us-east-1"
 }


### PR DESCRIPTION
Reverts serverless-ca/terraform-aws-ca#25
Including the provider in the module results in it being a "legacy" module which cannot be used in conjunction with count or for_each.