### PR TITLE
Increase Portability of Create-Package Script

### DIFF
--- a/modules/terraform-aws-ca-lambda/main.tf
+++ b/modules/terraform-aws-ca-lambda/main.tf
@@ -11,7 +11,8 @@ resource "null_resource" "install_python_dependencies" {
   }
 
   provisioner "local-exec" {
-    command = <<-EOT
+    interpreter = ["/bin/sh"]
+    command     = <<-EOT
       chmod +x ${path.module}/scripts/lambda-build/create-package.sh
       ${path.module}/scripts/lambda-build/create-package.sh
     EOT

--- a/modules/terraform-aws-ca-lambda/scripts/lambda-build/create-package.sh
+++ b/modules/terraform-aws-ca-lambda/scripts/lambda-build/create-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Executing create_package.sh..."
 

--- a/modules/terraform-aws-ca-lambda/scripts/lambda-build/create-package.sh
+++ b/modules/terraform-aws-ca-lambda/scripts/lambda-build/create-package.sh
@@ -21,7 +21,7 @@ dir_name=$function_name/
 mkdir -p $path_cwd/build/$dir_name
 
 # Create and activate virtual environment...
-virtualenv -p $runtime $path_cwd/build/env_$function_name
+python3 -m venv $path_cwd/build/env_$function_name
 source $path_cwd/build/env_$function_name/bin/activate
 
 # Installing python dependencies...


### PR DESCRIPTION
Make changes to increase the portability of this code.

1. Since the contents of [create-package.sh](https://github.com/serverless-ca/terraform-aws-ca/blob/main/modules/terraform-aws-ca-lambda/scripts/lambda-build/create-package.sh) don't contain anything BASH-specific, change the shebang from #!/bin/bash to #!/bin/sh. This allows for the script to run on Alpine Linux-based systems and containers, such as the [official Terraform Docker image](https://hub.docker.com/r/hashicorp/terraform). The interpreter for the local-exec provisioner was changed from default to `/bin/sh`.

2. Replace virtualenv usage with python3 -m venv. [Python 3.12 documentation](https://docs.python.org/3/tutorial/venv.html) states "[t]he module used to create and manage virtual environments is called venv." Importantly, this module is available as part of standard Python 3.12 installations on Mac (via brew), Ubuntu (via apt), and is available inside of the python:3.12-alpine container. virtualenv requires additional installation. Since the script has already confirmed that python3 is the version of python used by the lambda runtime, virtualenv's -p $runtime can be safely excluded.

These changes were tested in CI pipelines using a python:3.12-alpine container with Terraform 1.5.7 installed.

Closes #100.