### PR TITLE
Certificate renewal process: prevent private key reuse

### DIFF
--- a/docs/client-certificates.md
+++ b/docs/client-certificates.md
@@ -148,3 +148,25 @@ $filepath = "c:\tmp\test-example-com.crt"
 $decoded = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($input))
 $cert = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($decoded)) | Out-File -FilePath $filepath
 ```
+
+## Renewing Certificates
+
+**Renew certificate (Lambda)**
+
+* Create a new CSR using a new private key
+* Invoke the TLS Lambda function
+
+**Renew certificate (GitOps)**
+
+* Create a new CSR using a new private key
+* Overwrite the old CSR for the same common name
+* Run the pipeline
+
+**Private Key reuse**
+
+Best practice cryptographic security is not to reuse private keys.
+* If a private key has already been used for a previous certificate, the CA will reject the request
+* This behaviour can be overridden by adding a line to the JSON certificate request information:
+```json
+force_issue = True
+```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -103,5 +103,9 @@ Include the subject values you wish to override in the certificate request JSON.
 ### How can I change CRL lifetime?
 The default setting for CRL lifetime of 1 day should be appropriate for most use cases. However, the Issuing CA CRL lifetime, Root CA CRL lifetime, and publication frequency can be adjusted as detailed in [Revocation](revocation.md#crl-lifetime).
 
+### How do I renew a certificate?
+Create a new Certificate Signing Request (CSR) using a new private key. Resubmit as detailed in [Client Certificates](client-certificates.md#renewing-certificates).
+
+
 ### Can the CA be used for Application Load Balancer mTLS?
 A walkthrough with configuration of certificate authentication for AWS Application Load Balancer is provided in [How-to Guides](https://serverlessca.com/how-to-guides/alb/) and [this blog post](https://medium.com/@paulschwarzenberger/aws-application-load-balancer-mtls-with-open-source-cloud-ca-277cb40d60c7).

--- a/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
+++ b/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
@@ -13,8 +13,6 @@ from utils.certs.db import db_tls_cert_issued, db_list_certificates, db_issue_ce
 from utils.certs.s3 import s3_download
 from cryptography.x509 import load_pem_x509_certificate, load_pem_x509_csr
 from cryptography.hazmat.primitives.serialization import load_der_private_key
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
 # support legacy capability - to be removed in future release

--- a/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
+++ b/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
@@ -81,12 +81,23 @@ def sign_csr(csr, ca_name, csr_info_1, csr_info_2):
     return base64.b64encode(pem_certificate), info
 
 
-def is_invalid_certificate_request(ca_name, common_name, lifetime, force_issue):
+def get_public_key(base64_csr_data):
+    # base64 decode CSR
+    csr = load_pem_x509_csr(base64.standard_b64decode(base64_csr_data))
+
+    # get public key from CSR
+    return csr.public_key()
+
+
+def is_invalid_certificate_request(ca_name, common_name, lifetime, base64_csr_data, force_issue):
     if not db_list_certificates(ca_name):
         return {"error": f"CA {ca_name} not found"}
 
+    # get public key from CSR
+    request_public_key = get_public_key(base64_csr_data)
+
     # check if certificate already exists or is within 30 days of expiry
-    if not force_issue and not db_issue_certificate(common_name):
+    if not force_issue and not db_issue_certificate(common_name, request_public_key):
         return {"error": "Certificate already issued"}
 
     if lifetime < 1:
@@ -159,7 +170,9 @@ def lambda_handler(event, context):  # pylint:disable=unused-argument, too-many-
     cert_bundle = event.get("cert_bundle")  # boolean, include Root CA and Issuing CA with client certificate
     base64_csr_data = event.get("base64_csr_data")  # base64 encoded CSR PEM file
 
-    validation_error = is_invalid_certificate_request(issuing_ca_name, common_name, lifetime, force_issue)
+    validation_error = is_invalid_certificate_request(
+        issuing_ca_name, common_name, lifetime, base64_csr_data, force_issue
+    )
     if validation_error:
         return validation_error
 

--- a/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
+++ b/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
@@ -91,10 +91,12 @@ def is_invalid_certificate_request(ca_name, common_name, csr, lifetime, force_is
     public_key = csr.public_key()
 
     # Convert public key to PEM format
-    request_public_key_pem = public_key.public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
+    request_public_key_pem = (
+        public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    ).decode("utf-8")
 
     # check for private key reuse
     if not force_issue and not db_issue_certificate(common_name, request_public_key_pem):

--- a/modules/terraform-aws-ca-lambda/utils/certs/db.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/db.py
@@ -1,5 +1,6 @@
 import boto3
 import os
+import base64
 from datetime import datetime
 from cryptography.x509 import load_pem_x509_certificate
 
@@ -45,8 +46,8 @@ def db_issue_certificate(common_name, request_public_key):
     # if this is a request with a public key that's been used before, reject the request
     for certificate in certificates:
         serial_number = certificate["SerialNumber"]["S"]
-        pem_certificate = certificate["Certificate"]["B"]
-        cert = load_pem_x509_certificate(pem_certificate)
+        b64_encoded_certificate = certificate["Certificate"]["B"]
+        cert = load_pem_x509_certificate(base64.b64decode(b64_encoded_certificate))
         public_key = cert.public_key()
 
         if public_key == request_public_key:

--- a/modules/terraform-aws-ca-lambda/utils/certs/db.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/db.py
@@ -52,10 +52,12 @@ def db_issue_certificate(common_name, request_public_key_pem):
         public_key = cert.public_key()
 
         # Convert public key to PEM format
-        public_key_pem = public_key.public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
+        public_key_pem = (
+            public_key.public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+        ).decode("utf-8")
 
         if public_key_pem == request_public_key_pem:
             print(f"Private key has been used before for {common_name} certificate serial number {serial_number}")

--- a/tests/test_issued_certs.py
+++ b/tests/test_issued_certs.py
@@ -47,7 +47,6 @@ def test_cert_issued_no_passphrase():
         "base64_csr_data": base64_csr_data,
         "passphrase": False,
         "lifetime": 1,
-        "force_issue": True,
         "cert_bundle": True,
     }
 
@@ -108,7 +107,6 @@ def test_client_cert_issued_only_includes_client_auth_extension():
         "base64_csr_data": base64_csr_data,
         "passphrase": False,
         "lifetime": 1,
-        "force_issue": True,
         "cert_bundle": True,
     }
 
@@ -165,7 +163,6 @@ def test_cert_issued_with_passphrase():
         "common_name": common_name,
         "base64_csr_data": base64_csr_data,
         "lifetime": 1,
-        "force_issue": True,
         "cert_bundle": True,
     }
 
@@ -233,7 +230,6 @@ def test_issued_cert_includes_distinguished_name_specified_in_csr():
         "purposes": purposes,
         "base64_csr_data": base64_csr_data,
         "lifetime": 1,
-        "force_issue": True,
         "cert_bundle": True,
     }
 
@@ -301,7 +297,6 @@ def test_issued_cert_includes_correct_dns_names():
         "sans": sans,
         "base64_csr_data": base64_csr_data,
         "lifetime": 1,
-        "force_issue": True,
         "cert_bundle": True,
     }
 
@@ -369,7 +364,6 @@ def test_issued_cert_with_no_san_includes_correct_dns_name():
         "purposes": purposes,
         "base64_csr_data": base64_csr_data,
         "lifetime": 1,
-        "force_issue": True,
         "cert_bundle": True,
     }
 
@@ -437,7 +431,6 @@ def test_cert_issued_without_san_if_common_name_invalid_dns():
         "purposes": purposes,
         "base64_csr_data": base64_csr_data,
         "lifetime": 1,
-        "force_issue": True,
         "cert_bundle": True,
     }
 
@@ -509,7 +502,6 @@ def test_issued_cert_lifetime_as_expected():
         "purposes": purposes,
         "base64_csr_data": base64_csr_data,
         "lifetime": 1,
-        "force_issue": True,
         "cert_bundle": True,
     }
 
@@ -570,7 +562,6 @@ def test_max_cert_lifetime():
         "purposes": purposes,
         "base64_csr_data": base64_csr_data,
         "lifetime": 500,
-        "force_issue": True,
         "cert_bundle": True,
     }
 
@@ -645,7 +636,6 @@ def test_csr_uploaded_to_s3():
         "locality": override_locality,
         "organization": override_organization,
         "csr_file": csr_file,
-        "force_issue": True,
     }
 
     # Identify TLS certificate Lambda function
@@ -682,36 +672,10 @@ def test_no_private_key_reuse():
     csr_info = create_csr_info(common_name)
 
     # Generate Certificate Signing Request
-    csr_bytes = crypto_tls_cert_signing_request(private_key, csr_info)
-
-    # Convert from bytes to CertificateSigningRequest object
-    # Assuming `csr` is your bytes object containing the CSR
-    csr = x509.load_pem_x509_csr(csr_bytes, default_backend())
-    public_key = csr.public_key()
-
-    # Convert public key to PEM format
-    public_key_pem = (
-        public_key.public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-    ).decode("utf-8")
-
-    print(public_key_pem)
-
-    # Convert the CSR object to PEM format
-    # csr_pem = csr_object.public_bytes(serialization.Encoding.PEM)
-
-    # Load the CSR
-    # csr = x509.load_pem_x509_csr(csr_pem, default_backend())
-
-    # Extract the public key from the CSR
-    # public_key = csr.public_key()
-
-    # print(f"public key: {csr_pem.public_key()}")
+    csr = crypto_tls_cert_signing_request(private_key, csr_info)
 
     # Construct JSON data to pass to Lambda function
-    base64_csr_data = base64.b64encode(csr_bytes).decode("utf-8")
+    base64_csr_data = base64.b64encode(csr).decode("utf-8")
     json_data = {
         "common_name": common_name,
         "purposes": purposes,
@@ -733,10 +697,18 @@ def test_no_private_key_reuse():
     issued_common_name = response["CertificateInfo"]["CommonName"]
     print(f"Certificate issued for {issued_common_name}")
 
-    response = invoke_lambda(function_name, json_data)
-    print(response)
+    # Check 2nd request using same private key is rejected
+    response_2 = invoke_lambda(function_name, json_data)
+    print(response_2)
+    assert_that(response_2["error"]).is_equal_to("Private key has already been used for a certificate")
 
-    # check client auth extension is not present in certificate
-    # assert_that(invoke_lambda).raises(InvalidCertificateError).when_called_with(
-    #    function_name, json_data
-    # ).is_equal_to("The X.509 certificate provided is not valid for the purpose of client auth")
+    # Check override works
+    json_data["force_issue"] = True
+
+    # Invoke TLS certificate Lambda function
+    response_3 = invoke_lambda(function_name, json_data)
+    print(response_3)
+
+    # Inspect the response which includes the signed certificate
+    issued_common_name = response_3["CertificateInfo"]["CommonName"]
+    assert_that(issued_common_name).is_equal_to(common_name)

--- a/tests/test_issued_certs.py
+++ b/tests/test_issued_certs.py
@@ -690,10 +690,13 @@ def test_no_private_key_reuse():
     public_key = csr.public_key()
 
     # Convert public key to PEM format
-    public_key_pem = public_key.public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
+    public_key_pem = (
+        public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    ).decode("utf-8")
+
     print(public_key_pem)
 
     # Convert the CSR object to PEM format


### PR DESCRIPTION
- remove previous checks on days before expiry from certificate renewal process
- add check to prevent private key reuse
- test certificate request rejected if private key reused
- test ability to override using `force_issue = True` in JSON cert request info
- add documentation on certificate renewal process