### PR TITLE
Extract csr info and subject

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,6 +30,10 @@ jobs:
         run: |
           black --check --line-length 120 .
 
+      - name: Pytest
+        run: |
+          pytest -v modules/terraform-aws-ca-lambda
+
       - name: Prospector
         run: |
           prospector
@@ -53,4 +57,5 @@ jobs:
 
       - name: Bandit
         run: >
-          bandit -r src --ini .config/sast_python_bandit_cli.yml 
+          bandit -r modules/terraform-aws-ca-lambda/lambda_code modules/terraform-aws-ca-lambda/utils scripts tests utils
+          --ini .config/sast_python_bandit_cli.yml

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,7 @@
 name: Python tests
 on:
   workflow_dispatch:
+  pull_request:
   push:
     paths:
       - "**/*.py"

--- a/modules/terraform-aws-ca-lambda/lambda_code/create_issuing_ca/create_issuing_ca.py
+++ b/modules/terraform-aws-ca-lambda/lambda_code/create_issuing_ca/create_issuing_ca.py
@@ -52,7 +52,10 @@ def lambda_handler(event, context):  # pylint:disable=unused-argument
 
     # sign certificate
     pem_certificate = ca_kms_sign_ca_certificate_request(
-        csr, root_ca_cert, root_ca_kms_key_id, kms_describe_key(root_ca_kms_key_id)["SigningAlgorithms"][0]
+        csr,
+        root_ca_cert,
+        root_ca_kms_key_id,
+        kms_describe_key(root_ca_kms_key_id)["SigningAlgorithms"][0],
     )
     base64_certificate = base64.b64encode(pem_certificate)
 

--- a/modules/terraform-aws-ca-lambda/lambda_code/issuing_ca_crl/issuing_ca_crl.py
+++ b/modules/terraform-aws-ca-lambda/lambda_code/issuing_ca_crl/issuing_ca_crl.py
@@ -2,7 +2,11 @@ from cryptography.hazmat.primitives import serialization
 from utils.certs.kms import kms_get_kms_key_id, kms_get_public_key, kms_describe_key
 from utils.certs.crypto import crypto_ca_key_info, crypto_revoked_certificate
 from utils.certs.ca import ca_name, ca_kms_publish_crl
-from utils.certs.db import db_list_certificates, db_update_crl_number, db_revocation_date
+from utils.certs.db import (
+    db_list_certificates,
+    db_update_crl_number,
+    db_revocation_date,
+)
 from utils.certs.s3 import s3_download, s3_upload
 from cryptography.hazmat.primitives.serialization import load_der_public_key
 import datetime

--- a/modules/terraform-aws-ca-lambda/lambda_code/root_ca_crl/root_ca_crl.py
+++ b/modules/terraform-aws-ca-lambda/lambda_code/root_ca_crl/root_ca_crl.py
@@ -2,7 +2,11 @@ from cryptography.hazmat.primitives import serialization
 from utils.certs.kms import kms_get_kms_key_id, kms_get_public_key, kms_describe_key
 from utils.certs.crypto import crypto_ca_key_info, crypto_revoked_certificate
 from utils.certs.ca import ca_name, ca_kms_publish_crl
-from utils.certs.db import db_list_certificates, db_update_crl_number, db_revocation_date
+from utils.certs.db import (
+    db_list_certificates,
+    db_update_crl_number,
+    db_revocation_date,
+)
 from utils.certs.s3 import s3_download, s3_upload
 from cryptography.hazmat.primitives.serialization import load_der_public_key
 import datetime

--- a/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
+++ b/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
@@ -158,7 +158,7 @@ def create_csr_info(event):
     return csr_info
 
 
-def lambda_handler(event, context):  # pylint:disable=unused-argument, too-many-locals
+def lambda_handler(event, context):  # pylint:disable=unused-argument
 
     # get Issuing CA name
     issuing_ca_name = ca_name("issuing")

--- a/modules/terraform-aws-ca-lambda/requirements-dev.txt
+++ b/modules/terraform-aws-ca-lambda/requirements-dev.txt
@@ -6,3 +6,4 @@ prospector==1.10.3
 bandit==1.7.5
 requests==2.32.2
 validators==0.22.0
+pytest==8.2.2

--- a/modules/terraform-aws-ca-lambda/requirements-dev.txt
+++ b/modules/terraform-aws-ca-lambda/requirements-dev.txt
@@ -1,5 +1,6 @@
 boto3==1.34.64
 black==24.3.0
+setuptools==70.1.0
 cryptography==42.0.4
 prospector==1.10.3
 bandit==1.7.5

--- a/modules/terraform-aws-ca-lambda/requirements-dev.txt
+++ b/modules/terraform-aws-ca-lambda/requirements-dev.txt
@@ -1,9 +1,10 @@
-boto3==1.34.64
-black==24.3.0
 setuptools==70.1.0
-cryptography==42.0.4
+boto3==1.34.128
+black==24.4.2
+cryptography==42.0.8
 prospector==1.10.3
-bandit==1.7.5
-requests==2.32.2
-validators==0.22.0
+bandit==1.7.9
 pytest==8.2.2
+validators==0.28.3
+requests==2.32.3
+

--- a/modules/terraform-aws-ca-lambda/utils/certs/ca.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/ca.py
@@ -335,7 +335,7 @@ def subject_from_ca_info(ca_info, default_common_name=None):
     return subject
 
 
-def ca_kms_publish_crl(  # pylint:disable=too-many-locals
+def ca_kms_publish_crl(
     ca_key_info,
     time_delta,
     revoked_certs,

--- a/modules/terraform-aws-ca-lambda/utils/certs/ca.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/ca.py
@@ -13,7 +13,11 @@ from cryptography.x509 import (
 from cryptography.x509.oid import AuthorityInformationAccessOID, ExtendedKeyUsageOID
 from cryptography.hazmat.primitives import serialization
 from validators import domain as domain_validator
-from utils.certs.crypto import crypto_select_class, crypto_hash_algorithm, crypto_hash_class
+from utils.certs.crypto import (
+    crypto_select_class,
+    crypto_hash_algorithm,
+    crypto_hash_class,
+)
 
 
 domain = os.environ.get("DOMAIN")
@@ -148,8 +152,14 @@ def ca_kms_sign_ca_certificate_request(
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.now(timezone.utc))
         .not_valid_after(datetime.now(timezone.utc) + timedelta(days=lifetime))
-        .add_extension(x509.SubjectKeyIdentifier.from_public_key(csr_cert.public_key()), critical=False)
-        .add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_cert.public_key()), critical=False)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(csr_cert.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_cert.public_key()),
+            critical=False,
+        )
         .add_extension(
             x509.KeyUsage(
                 digital_signature=True,
@@ -229,12 +239,18 @@ def ca_build_cert(csr_cert, ca_cert, lifetime, delta, cert_request_info):
             x509.CertificatePolicies([PolicyInformation(ObjectIdentifier("2.23.140.1.2.1"), None)]),
             critical=False,
         )
-        .add_extension(x509.SubjectKeyIdentifier.from_public_key(csr_cert.public_key()), critical=False)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(csr_cert.public_key()),
+            critical=False,
+        )
     )
 
 
 def ca_kms_sign_tls_certificate_request(
-    cert_request_info, ca_cert, kms_key_id, kms_signing_algorithm="RSASSA_PKCS1_V1_5_SHA_256"
+    cert_request_info,
+    ca_cert,
+    kms_key_id,
+    kms_signing_algorithm="RSASSA_PKCS1_V1_5_SHA_256",
 ):
     csr_cert = cert_request_info["CsrCert"]
     x509_dns_names = cert_request_info["x509Sans"]
@@ -330,7 +346,10 @@ def ca_create_root_ca(public_key, private_key, kms_signing_algorithm="RSASSA_PKC
             critical=True,
         )
         .add_extension(x509.SubjectKeyIdentifier.from_public_key(public_key), critical=False)
-        .add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key),
+            critical=False,
+        )
         .sign(private_key, crypto_hash_class(kms_signing_algorithm))
     )
 
@@ -355,7 +374,11 @@ def ca_get_ca_info(issuing_ca_info, root_ca_info):
 
 
 def ca_kms_publish_crl(  # pylint:disable=too-many-locals
-    ca_key_info, time_delta, revoked_certs, crl_number, kms_signing_algorithm="RSASSA_PKCS1_V1_5_SHA_256"
+    ca_key_info,
+    time_delta,
+    revoked_certs,
+    crl_number,
+    kms_signing_algorithm="RSASSA_PKCS1_V1_5_SHA_256",
 ):
     """Publishes certificate revocation list signed by private key in KMS"""
     kms_key_id = ca_key_info["KmsKeyId"]

--- a/modules/terraform-aws-ca-lambda/utils/certs/ca.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/ca.py
@@ -3,7 +3,6 @@ import json
 
 from datetime import datetime, timezone, timedelta
 from cryptography import x509
-from cryptography.x509.oid import NameOID
 from cryptography.x509 import (
     AccessDescription,
     UniformResourceIdentifier,
@@ -13,13 +12,14 @@ from cryptography.x509 import (
 from cryptography.x509.oid import AuthorityInformationAccessOID, ExtendedKeyUsageOID
 from cryptography.hazmat.primitives import serialization
 from validators import domain as domain_validator
-from utils.certs.crypto import (
+from .crypto import (
     crypto_select_class,
     crypto_hash_algorithm,
     crypto_hash_class,
+    Subject,
 )
 
-
+# TODO: How can we get rid of these globals?
 domain = os.environ.get("DOMAIN")
 env_name = os.environ["ENVIRONMENT_NAME"]
 issuing_ca_info = json.loads(os.environ["ISSUING_CA_INFO"])
@@ -38,84 +38,30 @@ def ca_name(hierarchy):
 
 def ca_construct_subject_name(ca_info, ca_hierarchy_type="root"):
     """Constructs subject name for CA certificate"""
-    country = ca_info.get("country")
-    state = ca_info.get("state")
-    locality = ca_info.get("locality")
-    organization = ca_info.get("organization")
-    organizational_unit = ca_info.get("organizationalUnit")
-    common_name = ca_info.get("commonName") or f"Serverless {ca_hierarchy_type.title()} CA"
-    email_address = ca_info.get("emailAddress")
+    default_common_name = f"Serverless {ca_hierarchy_type.title()} CA"
 
-    attributes = [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+    subject = subject_from_ca_info(ca_info, default_common_name=default_common_name)
 
-    if country:
-        attributes.append(x509.NameAttribute(NameOID.COUNTRY_NAME, country))
-
-    if email_address:
-        attributes.append(x509.NameAttribute(NameOID.EMAIL_ADDRESS, email_address))
-
-    if locality:
-        attributes.append(x509.NameAttribute(NameOID.LOCALITY_NAME, locality))
-
-    if organization:
-        attributes.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, organization))
-
-    if organizational_unit:
-        attributes.append(x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit))
-
-    if state:
-        attributes.append(x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, state))
-
-    return x509.Name(attributes)
-
-
-def get_subject_attribute_or_none(csr_cert, attribute):
-    if csr_cert.subject.get_attributes_for_oid(attribute):
-        return csr_cert.subject.get_attributes_for_oid(attribute)[0].value
-    return None
+    return subject.x509_name()
 
 
 def tls_cert_construct_subject_name(csr_cert, cert_request_info):
     """Constructs subject name for end entity certificate"""
     # subject values from CSR
-    common_name = csr_cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
-    country = get_subject_attribute_or_none(csr_cert, NameOID.COUNTRY_NAME)
-    email_address = get_subject_attribute_or_none(csr_cert, NameOID.EMAIL_ADDRESS)
-    locality = get_subject_attribute_or_none(csr_cert, NameOID.LOCALITY_NAME)
-    state = get_subject_attribute_or_none(csr_cert, NameOID.STATE_OR_PROVINCE_NAME)
-    organization = get_subject_attribute_or_none(csr_cert, NameOID.ORGANIZATION_NAME)
-    organizational_unit = get_subject_attribute_or_none(csr_cert, NameOID.ORGANIZATIONAL_UNIT_NAME)
+    orig_subject = Subject.from_x509_subject(csr_cert.subject)
 
     # overwrite subject values from CSR with cert_request_info values if present
-    common_name = cert_request_info.get("CommonName") or common_name
-    country = cert_request_info.get("Country") or country
-    email_address = cert_request_info.get("EmailAddress") or email_address
-    state = cert_request_info.get("State") or state
-    locality = cert_request_info.get("Locality") or locality
-    organization = cert_request_info.get("Organization") or organization
-    organizational_unit = cert_request_info.get("OrganizationalUnit") or organizational_unit
+    common_name = cert_request_info.get("CommonName") or orig_subject.common_name
 
-    attributes = [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+    subject = Subject(common_name)
+    subject.country = cert_request_info.get("Country") or orig_subject.country
+    subject.email_address = cert_request_info.get("EmailAddress") or orig_subject.email_address
+    subject.state = cert_request_info.get("State") or orig_subject.state
+    subject.locality = cert_request_info.get("Locality") or orig_subject.locality
+    subject.organization = cert_request_info.get("Organization") or orig_subject.organization
+    subject.organizational_unit = cert_request_info.get("OrganizationalUnit") or orig_subject.organizational_unit
 
-    if country:
-        attributes.append(x509.NameAttribute(NameOID.COUNTRY_NAME, country))
-
-    if email_address:
-        attributes.append(x509.NameAttribute(NameOID.EMAIL_ADDRESS, email_address))
-
-    if locality:
-        attributes.append(x509.NameAttribute(NameOID.LOCALITY_NAME, locality))
-
-    if organization:
-        attributes.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, organization))
-
-    if organizational_unit:
-        attributes.append(x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit))
-
-    if state:
-        attributes.append(x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, state))
-
-    return x509.Name(attributes)
+    return subject.x509_name()
 
 
 def ca_kms_sign_ca_certificate_request(
@@ -373,6 +319,22 @@ def ca_get_ca_info(issuing_ca_info, root_ca_info):
     return root_ca_info
 
 
+def subject_from_ca_info(ca_info, default_common_name=None):
+    common_name = ca_info.get("commonName")
+    if default_common_name:
+        common_name = common_name or default_common_name
+
+    subject = Subject(common_name)
+    subject.country = ca_info.get("country")
+    subject.state = ca_info.get("state")
+    subject.locality = ca_info.get("locality")
+    subject.organization = ca_info.get("organization")
+    subject.organizational_unit = ca_info.get("organizationalUnit")
+    subject.email_address = ca_info.get("emailAddress")
+
+    return subject
+
+
 def ca_kms_publish_crl(  # pylint:disable=too-many-locals
     ca_key_info,
     time_delta,
@@ -386,35 +348,9 @@ def ca_kms_publish_crl(  # pylint:disable=too-many-locals
 
     ca_info = ca_get_ca_info(issuing_ca_info, root_ca_info)
 
-    country = ca_info.get("country")
-    state = ca_info.get("state")
-    locality = ca_info.get("locality")
-    organization = ca_info.get("organization")
-    organizational_unit = ca_info.get("organizationalUnit")
-    common_name = ca_info.get("commonName") or "Serverless Root CA"
-    email_address = ca_info.get("emailAddress")
+    subject = subject_from_ca_info(ca_info, "Serverless Root CA")
 
-    attributes = [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
-
-    if country:
-        attributes.append(x509.NameAttribute(NameOID.COUNTRY_NAME, country))
-
-    if email_address:
-        attributes.append(x509.NameAttribute(NameOID.EMAIL_ADDRESS, email_address))
-
-    if locality:
-        attributes.append(x509.NameAttribute(NameOID.LOCALITY_NAME, locality))
-
-    if organization:
-        attributes.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, organization))
-
-    if organizational_unit:
-        attributes.append(x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit))
-
-    if state:
-        attributes.append(x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, state))
-
-    issuer = x509.Name(attributes)
+    issuer = subject.x509_name()
 
     builder = x509.CertificateRevocationListBuilder()
     builder = builder.issuer_name(x509.Name(issuer))
@@ -435,41 +371,23 @@ def ca_kms_publish_crl(  # pylint:disable=too-many-locals
 def ca_client_tls_cert_signing_request(private_key, csr_info, kms_signing_algorithm="RSASSA_PKCS1_V1_5_SHA_256"):
 
     # get CSR info, using Issuing CA info if needed
-    country = csr_info.get("country") or issuing_ca_info.get("country")
-    state = csr_info.get("state") or issuing_ca_info.get("state")
-    locality = csr_info.get("locality") or issuing_ca_info.get("locality")
-    organization = csr_info.get("organization") or issuing_ca_info.get("organization")
-    organizational_unit = csr_info.get("organizationalUnit")
     common_name = csr_info.get("commonName")
-    email_address = csr_info.get("emailAddress")
+    subject = Subject(common_name)
+    subject.country = csr_info.get("country") or issuing_ca_info.get("country")
+    subject.state = csr_info.get("state") or issuing_ca_info.get("state")
+    subject.locality = csr_info.get("locality") or issuing_ca_info.get("locality")
+    subject.organization = csr_info.get("organization") or issuing_ca_info.get("organization")
+    subject.organizational_unit = csr_info.get("organizationalUnit")
 
-    attributes = [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+    subject.email_address = csr_info.get("emailAddress")
 
-    if country:
-        attributes.append(x509.NameAttribute(NameOID.COUNTRY_NAME, country))
-
-    if email_address:
-        attributes.append(x509.NameAttribute(NameOID.EMAIL_ADDRESS, email_address))
-
-    if locality:
-        attributes.append(x509.NameAttribute(NameOID.LOCALITY_NAME, locality))
-
-    if organization:
-        attributes.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, organization))
-
-    if organizational_unit:
-        attributes.append(x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit))
-
-    if state:
-        attributes.append(x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, state))
-
-    subject = x509.Name(attributes)
+    subject_x509_name = subject.x509_name()
 
     if domain_validator(common_name):
         csr = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(
-                x509.Name(subject),
+                x509.Name(subject_x509_name),
             )
             .add_extension(
                 x509.SubjectAlternativeName(
@@ -486,7 +404,7 @@ def ca_client_tls_cert_signing_request(private_key, csr_info, kms_signing_algori
         csr = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(
-                x509.Name(subject),
+                x509.Name(subject_x509_name),
             )
             .sign(private_key, crypto_hash_class(kms_signing_algorithm))
         )

--- a/modules/terraform-aws-ca-lambda/utils/certs/crypto.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/crypto.py
@@ -5,8 +5,111 @@ import base64
 from cryptography import x509
 from cryptography.x509.oid import NameOID
 from cryptography.hazmat.primitives import hashes, serialization
-from utils.certs.crypto_kms_classes import AWSKMSEllipticCurvePrivateKey, AWSKMSRSAPrivateKey
+from .crypto_kms_classes import (
+    AWSKMSEllipticCurvePrivateKey,
+    AWSKMSRSAPrivateKey,
+)
 from validators import domain as domain_validator
+
+from typing import Optional
+
+
+def get_subject_attribute_or_none(x509_subject, attribute):
+    if x509_subject.get_attributes_for_oid(attribute):
+        return x509_subject.get_attributes_for_oid(attribute)[0].value
+    return None
+
+
+class Subject:
+    def __init__(self, common_name: str):
+        self.common_name = common_name
+        self.locality: Optional[str] = None
+        self.organization: Optional[str] = None
+        self.organizational_unit: Optional[str] = None
+        self.country: Optional[str] = None
+        self.state: Optional[str] = None
+        self.email_address: Optional[str] = None
+
+    def x509_name(self):
+        attributes = [x509.NameAttribute(NameOID.COMMON_NAME, self.common_name)]
+
+        if self.country:
+            attributes.append(x509.NameAttribute(NameOID.COUNTRY_NAME, self.country))
+
+        if self.email_address:
+            attributes.append(x509.NameAttribute(NameOID.EMAIL_ADDRESS, self.email_address))
+
+        if self.locality:
+            attributes.append(x509.NameAttribute(NameOID.LOCALITY_NAME, self.locality))
+
+        if self.organization:
+            attributes.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, self.organization))
+
+        if self.organizational_unit:
+            attributes.append(x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, self.organizational_unit))
+
+        if self.state:
+            attributes.append(x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, self.state))
+
+        return x509.Name(attributes)
+
+    @staticmethod
+    def from_x509_subject(x509_subject: "Subject"):
+        common_name = x509_subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+
+        subject = Subject(common_name)
+        subject.country = get_subject_attribute_or_none(x509_subject, NameOID.COUNTRY_NAME)
+        subject.email_address = get_subject_attribute_or_none(x509_subject, NameOID.EMAIL_ADDRESS)
+        subject.locality = get_subject_attribute_or_none(x509_subject, NameOID.LOCALITY_NAME)
+        subject.state = get_subject_attribute_or_none(x509_subject, NameOID.STATE_OR_PROVINCE_NAME)
+        subject.organization = get_subject_attribute_or_none(x509_subject, NameOID.ORGANIZATION_NAME)
+        subject.organizational_unit = get_subject_attribute_or_none(x509_subject, NameOID.ORGANIZATIONAL_UNIT_NAME)
+
+        return subject
+
+
+class CsrInfo:
+    def __init__(self, common_name, lifetime: int = 30, purposes=None, sans=None):
+        self.subject = Subject(common_name)
+
+        self.lifetime: int = lifetime
+
+        self._purposes = ["client_auth"]
+        if purposes is not None:
+            self._purposes = purposes
+
+        self._sans = []
+        if sans is not None:
+            self._sans = sans
+
+    def get_purposes(self):
+        # only allowed purposes are client_auth and server_auth
+        purposes = list(filter(lambda x: x in ["client_auth", "server_auth"], self._purposes))
+        # purposes = [p for p in purposes if p in ["client_auth", "server_auth"]]
+
+        # if purposes list is empty, default to client auth
+        if not purposes:
+            purposes = ["client_auth"]
+
+        return purposes
+
+    def get_sans(self):
+        sans = self._sans
+
+        valid_common_name = domain_validator(self.subject.common_name)
+
+        # no SANs and common name is not a valid domain
+        if (sans is None or sans == []) and not valid_common_name:
+            sans = []
+
+        # no SANs and common name is a valid domain
+        if (sans is None or sans == []) and valid_common_name:
+            sans = [self.subject.common_name]
+
+        # remove invalid SANs
+        sans = [s for s in sans if domain_validator(s)]
+
+        return sans
 
 
 def crypto_cert_info(cert, common_name):
@@ -26,37 +129,14 @@ def crypto_ca_key_info(public_key, kms_key_id, common_name):
     }
 
 
-def crypto_cert_request_info(csr_cert, csr_info_1, csr_info_2):
+def crypto_cert_request_info(csr_cert, csr_info):
     """Creates a dictionary with the information needed to sign a certificate"""
-    # get common name from csr_info_1
-    common_name = csr_info_1["commonName"]
+    # get common name from csr_info
+    common_name = csr_info.subject.common_name
 
-    # get values from csr_info_2
-    purposes = csr_info_2.get("purposes")
-    lifetime = csr_info_2.get("lifetime")
-    sans = csr_info_2.get("sans")
-
-    # if no purposes are specified, default to both client auth
-    if purposes is None:
-        purposes = ["client_auth"]
-
-    # only allowed purposes are client_auth and server_auth
-    purposes = [p for p in purposes if p in ["client_auth", "server_auth"]]
-
-    # if purposes list is empty, default to client auth
-    if purposes == []:
-        purposes = ["client_auth"]
-
-    # no SANs and common name is not a valid domain
-    if (sans is None or sans == []) and not domain_validator(common_name):
-        sans = []
-
-    # no SANs and common name is a valid domain
-    if (sans is None or sans == []) and domain_validator(common_name):
-        sans = [common_name]
-
-    # remove invalid SANs
-    sans = [s for s in sans if domain_validator(s)]
+    # get values from csr_info
+    purposes = csr_info.get_purposes()
+    sans = csr_info.get_sans()
 
     # convert to x509 cryptography format
     x509_sans = []
@@ -65,15 +145,15 @@ def crypto_cert_request_info(csr_cert, csr_info_1, csr_info_2):
 
     return {
         "CommonName": common_name,
-        "Country": csr_info_1["country"],
+        "Country": csr_info.subject.country,
         "CsrCert": csr_cert,
-        "EmailAddress": csr_info_2["emailAddress"],
-        "Lifetime": lifetime,
-        "Locality": csr_info_1["locality"],
-        "Organization": csr_info_1["organization"],
-        "OrganizationalUnit": csr_info_1["organizationalUnit"],
+        "EmailAddress": csr_info.subject.email_address,
+        "Lifetime": csr_info.lifetime,
+        "Locality": csr_info.subject.locality,
+        "Organization": csr_info.subject.organization,
+        "OrganizationalUnit": csr_info.subject.organizational_unit,
         "Purposes": purposes,
-        "State": csr_info_2["state"],
+        "State": csr_info.subject.state,
         "x509Sans": x509_sans,
     }
 

--- a/modules/terraform-aws-ca-lambda/utils/certs/crypto_kms_classes.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/crypto_kms_classes.py
@@ -7,7 +7,11 @@ from cryptography.hazmat.primitives import hashes
 class AWSKMSEllipticCurvePrivateKey(ec.EllipticCurvePrivateKey):
     """class for AWS KMS Elliptic Curve Private Key to be used with cryptography library"""
 
-    signature_algorithm_lookup = {"sha256": "ECDSA_SHA_256", "sha384": "ECDSA_SHA_384", "sha512": "ECDSA_SHA_512"}
+    signature_algorithm_lookup = {
+        "sha256": "ECDSA_SHA_256",
+        "sha384": "ECDSA_SHA_384",
+        "sha512": "ECDSA_SHA_512",
+    }
 
     _evp_pkey = None
 
@@ -136,7 +140,12 @@ class AWSKMSRSAPrivateKey(rsa.RSAPrivateKey):
     def public_key(self) -> rsa.RSAPublicKey:
         return AWSKMSRSAPublicKey(self.keyid)
 
-    def sign(self, data: bytes, padding: rsa.AsymmetricPadding, algorithm: hashes.HashAlgorithm) -> bytes:
+    def sign(
+        self,
+        data: bytes,
+        padding: rsa.AsymmetricPadding,
+        algorithm: hashes.HashAlgorithm,
+    ) -> bytes:
         algorithm.name = "sha256"
 
         try:
@@ -161,7 +170,11 @@ class AWSKMSRSAPublicKey(AWSKMSRSAPrivateKey):
         raise NotImplementedError("Encrypt not supported")
 
     def verify(
-        self, signature: bytes, data: bytes, padding: AsymmetricPadding, algorithm: hashes.HashAlgorithm
+        self,
+        signature: bytes,
+        data: bytes,
+        padding: AsymmetricPadding,
+        algorithm: hashes.HashAlgorithm,
     ) -> None:
         raise NotImplementedError("Verify not supported")
 

--- a/modules/terraform-aws-ca-lambda/utils/certs/test_crypto.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/test_crypto.py
@@ -1,0 +1,107 @@
+from cryptography.x509.oid import NameOID
+
+from .crypto import CsrInfo, Subject
+
+
+# test defaults
+def test_csr_info_defaults():
+    csr_info = CsrInfo("blah.example.com")
+
+    assert csr_info.lifetime == 30
+    assert csr_info.get_purposes() == ["client_auth"]
+    assert csr_info.get_sans() == ["blah.example.com"]
+
+
+def test_csr_info_with_sans():
+    csr_info = CsrInfo("blah.example.com", sans=["foo.example.com"])
+
+    assert csr_info.get_sans() == ["foo.example.com"]
+
+
+# If an invalid SAN is supplied we ignore it
+def test_csr_info_with_invalid_sans():
+    csr_info = CsrInfo("blah.example.com", sans=["foo.example com"])
+
+    assert csr_info.get_sans() == []
+
+
+# if invalid and valid SANs are specified we filter out the invalid ones
+def test_csr_info_with_invalid_and_valid_sans():
+    csr_info = CsrInfo("blah.example.com", sans=["foo.example com", "bar.example.com"])
+
+    assert csr_info.get_sans() == ["bar.example.com"]
+
+
+def test_csr_info_with_purpose():
+    csr_info = CsrInfo("blah.example.com", purposes=["server_auth"])
+
+    assert csr_info.get_purposes() == ["server_auth"]
+
+
+# If an invalid purpose is specified, we default to 'client_auth'
+def test_csr_info_with_invalid_purpose():
+    csr_info = CsrInfo("blah.example.com", purposes=["code_sign"])
+
+    assert csr_info.get_purposes() == ["client_auth"]
+
+
+# If valid and invalid purposes are specified, we filter out invalid/unsupported purposes
+# and keep the valid / supported ones
+def test_csr_info_with_invalid_and_valid_purposes():
+    csr_info = CsrInfo("blah.example.com", purposes=["code_sign", "server_auth"])
+
+    assert csr_info.get_purposes() == ["server_auth"]
+
+
+def test_subject_x509_name_simple():
+    subject = Subject("blah.example.com")
+
+    x509_name = subject.x509_name()
+
+    assert x509_name.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == "blah.example.com"
+    assert x509_name.rfc4514_string() == "CN=blah.example.com"
+
+
+def test_subject_x509_name():
+    subject = Subject("blah.example.com")
+    subject.country = "GB"
+    subject.email_address = "test@example.com"
+    subject.locality = "London"
+    subject.organization = "Acme"
+    subject.organizational_unit = "Gardening"
+    subject.state = "England"
+
+    x509_name = subject.x509_name()
+
+    assert x509_name.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == "blah.example.com"
+    assert x509_name.get_attributes_for_oid(NameOID.COUNTRY_NAME)[0].value == "GB"
+    assert x509_name.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)[0].value == "test@example.com"
+    assert x509_name.get_attributes_for_oid(NameOID.LOCALITY_NAME)[0].value == "London"
+    assert x509_name.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)[0].value == "Acme"
+    assert x509_name.get_attributes_for_oid(NameOID.ORGANIZATIONAL_UNIT_NAME)[0].value == "Gardening"
+    assert x509_name.get_attributes_for_oid(NameOID.STATE_OR_PROVINCE_NAME)[0].value == "England"
+
+    expected = "ST=England,OU=Gardening,O=Acme,L=London,1.2.840.113549.1.9.1=test@example.com,C=GB,CN=blah.example.com"
+    assert x509_name.rfc4514_string() == expected
+
+
+def test_subject_from_x509_name():
+    subject = Subject("blah.example.com")
+    subject.country = "GB"
+    subject.email_address = "test@example.com"
+    subject.locality = "London"
+    subject.organization = "Acme"
+    subject.organizational_unit = "Gardening"
+    subject.state = "England"
+
+    x509_name = subject.x509_name()
+
+    new_subject = Subject.from_x509_subject(x509_name)
+
+    assert subject.common_name == new_subject.common_name
+    assert subject.country == new_subject.country
+    assert subject.email_address == new_subject.email_address
+    assert subject.locality == new_subject.locality
+    assert subject.organization == new_subject.organization
+    assert subject.organizational_unit == new_subject.organizational_unit
+    assert subject.state == new_subject.state

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements-docs.txt
-setuptools==70.0.0
+setuptools==70.1.0
 assertpy==1.1
 boto3==1.34.128
 black==24.4.2


### PR DESCRIPTION
This PR deduplicates a few areas of the code base when working with CSRs and certificate subjects.

It replaces `create_csr_info_1` and `create_csr_info_2` with something I think is easier to read. 
It also deduplicates various locations that serialise and deseriallise subject names. It also adds some unit tests for this work.