### PR TITLE
Remove lifecycle policy from external S3 bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,12 +60,12 @@ module "internal_s3" {
   # S3 bucket for internal processing of JSON files for certificates to be issued and revoked
   source = "./modules/terraform-aws-ca-s3"
 
-  purpose          = "${var.project}-ca-internal-${var.env}"
-  global_bucket    = true
-  bucket_prefix    = var.bucket_prefix
-  access_logs      = var.access_logs
-  log_bucket       = var.log_bucket
-  kms_key_alias    = var.kms_key_alias == "" ? module.kms_tls_keygen.kms_alias_arn : var.kms_key_alias
+  purpose       = "${var.project}-ca-internal-${var.env}"
+  global_bucket = true
+  bucket_prefix = var.bucket_prefix
+  access_logs   = var.access_logs
+  log_bucket    = var.log_bucket
+  kms_key_alias = var.kms_key_alias == "" ? module.kms_tls_keygen.kms_alias_arn : var.kms_key_alias
 }
 
 resource "aws_s3_object" "cert_info" {

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ module "dynamodb" {
 }
 
 module "external_s3" {
+  #checkov:skip=CKV2_AWS_61:Lifecycle configuration not needed for long-lived static content
   # S3 bucket for CRL and CA certificate publication
   source = "./modules/terraform-aws-ca-s3"
 

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,6 @@ module "internal_s3" {
   bucket_prefix    = var.bucket_prefix
   access_logs      = var.access_logs
   log_bucket       = var.log_bucket
-  lifecycle_policy = false
   kms_key_alias    = var.kms_key_alias == "" ? module.kms_tls_keygen.kms_alias_arn : var.kms_key_alias
 }
 

--- a/modules/terraform-aws-ca-s3/variables.tf
+++ b/modules/terraform-aws-ca-s3/variables.tf
@@ -121,7 +121,7 @@ variable "filter_suffix" {
 
 variable "lifecycle_policy" {
   description = "Include lifecycle policy"
-  default     = true
+  default     = false
 }
 
 variable "ia_transition" {


### PR DESCRIPTION
- Remove lifecycle policy from external S3 bucket
- This fixes an issue where scripts or processes downloading the CA bundle or CA certs from this bucket fail after 180 days as these objects are transitioned to Glacier
- If your CA was created over 180 days ago, initiate a Glacier restore on objects in the external S3 bucket before upgrading to this version