### PR TITLE
Chore/fix setuptools for 3.12

### DIFF
--- a/modules/terraform-aws-ca-lambda/requirements-dev.txt
+++ b/modules/terraform-aws-ca-lambda/requirements-dev.txt
@@ -1,8 +1,8 @@
-boto3==1.34.64
-black==24.3.0
 setuptools==70.2.0
-cryptography==42.0.4
+boto3==1.34.141
+black==24.4.2
+cryptography==42.0.8
 prospector==1.10.3
-bandit==1.7.5
-requests==2.32.2
-validators==0.22.0
+bandit==1.7.9
+validators==0.31.0
+requests==2.32.3

--- a/modules/terraform-aws-ca-lambda/requirements-dev.txt
+++ b/modules/terraform-aws-ca-lambda/requirements-dev.txt
@@ -1,5 +1,6 @@
 boto3==1.34.64
 black==24.3.0
+setuptools==70.2.0
 cryptography==42.0.4
 prospector==1.10.3
 bandit==1.7.5


### PR DESCRIPTION
As suggested by https://stackoverflow.com/questions/7446187/no-module-named-pkg-resources
