### PR TITLE
feat: add docker to build terraform-aws-ca-lambda

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -1,7 +1,8 @@
 # ECDSA Certificate Authority with private CRL (default)
 
 ## Local Development - Terraform
-from within this subdirectory:
+* You need to have docker installed
+* from within this subdirectory:
 ```
 terraform init -backend-config=bucket={YOUR_TERRAFORM_STATE_BUCKET} -backend-config=key=terraform-aws-ca -backend-config=region={YOUR_TERRAFORM_STATE_REGION}
 terraform plan

--- a/modules/terraform-aws-ca-lambda/Dockerfile
+++ b/modules/terraform-aws-ca-lambda/Dockerfile
@@ -15,13 +15,11 @@ ENV PATH_CWD=/workspace \
 
 WORKDIR /workspace
 
-# Copiar o script e arquivos necessários para o contêiner
 COPY scripts/lambda-build/create-package.sh /workspace/scripts/lambda-build/create-package.sh
 COPY lambda_code /workspace/lambda_code
 COPY utils /workspace/utils
 
-# Tornar o script executável
+
 RUN chmod +x /workspace/scripts/lambda-build/create-package.sh
 
-# Comando padrão para execução do contêiner
 CMD ["/workspace/scripts/lambda-build/create-package.sh"]

--- a/modules/terraform-aws-ca-lambda/Dockerfile
+++ b/modules/terraform-aws-ca-lambda/Dockerfile
@@ -1,0 +1,27 @@
+FROM public.ecr.aws/docker/library/python:3.12.4-slim
+
+RUN apt-get update && apt-get install -y \
+    zip \
+    unzip \
+    build-essential \
+    libpoppler-cpp-dev \
+    pkg-config python3-dev && \
+    apt-get clean && rm -rf /var/cache/apt/lists && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip
+
+ENV PATH_CWD=/workspace \
+    PLATFORM=manylinux2014_x86_64
+
+WORKDIR /workspace
+
+# Copiar o script e arquivos necessários para o contêiner
+COPY scripts/lambda-build/create-package.sh /workspace/scripts/lambda-build/create-package.sh
+COPY lambda_code /workspace/lambda_code
+COPY utils /workspace/utils
+
+# Tornar o script executável
+RUN chmod +x /workspace/scripts/lambda-build/create-package.sh
+
+# Comando padrão para execução do contêiner
+CMD ["/workspace/scripts/lambda-build/create-package.sh"]

--- a/modules/terraform-aws-ca-lambda/README.MD
+++ b/modules/terraform-aws-ca-lambda/README.MD
@@ -1,11 +1,12 @@
 # Terraform submodule for AWS Lambda
 * Deploys AWS Lambda functions forming part of serverless CA solution
 * Submodule of terraform-aws-ca
+* You need to have docker installed
 
 ## Local Python development - MacOS / Linux
 * create virtual environment
 ```bash
-cd modules\terraform-aws-ca-lambda
+cd modules/terraform-aws-ca-lambda
 python -m venv .venv
 ```
 * activate virtual environment

--- a/modules/terraform-aws-ca-lambda/main.tf
+++ b/modules/terraform-aws-ca-lambda/main.tf
@@ -14,15 +14,21 @@ resource "null_resource" "install_python_dependencies" {
     interpreter = ["/bin/sh", "-c"]
     command     = <<-EOT
       chmod +x ${path.module}/scripts/lambda-build/create-package.sh
-      ${path.module}/scripts/lambda-build/create-package.sh
+      docker build -t lambda-build-image ${path.module}
+      docker run --rm \
+        -e function_name=${local.file_name} \
+        -e runtime=${var.runtime} \
+        -e path_cwd=/workspace \
+        -e platform=${var.platform} \
+        -v $(realpath ${path.module}/build):/workspace/build \
+        lambda-build-image
     EOT
 
     environment = {
-      source_code_path = "${path.module}/lambda_code"
-      function_name    = local.file_name
-      runtime          = var.runtime
-      path_cwd         = path.module
-      platform         = var.platform
+      function_name = local.file_name
+      runtime       = var.runtime
+      path_cwd      = path.module
+      platform      = var.platform
     }
   }
 }


### PR DESCRIPTION
To facilitate project implementation by minimizing environment incompatibility issues, a docker image was added to the project to facilitate this task, ensuring environment consistency.