### PR TITLE
Disable key rotation for KMS key used by S3

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -35,7 +35,7 @@
 | <a name="module_rsa_tls_cert_lambda"></a> [rsa\_tls\_cert\_lambda](#module\_rsa\_tls\_cert\_lambda) | ./modules/terraform-aws-ca-lambda | n/a |
 | <a name="module_scheduler"></a> [scheduler](#module\_scheduler) | ./modules/terraform-aws-ca-scheduler | n/a |
 | <a name="module_scheduler-role"></a> [scheduler-role](#module\_scheduler-role) | ./modules/terraform-aws-ca-iam | n/a |
-| <a name="module_sns-ca-notifications"></a> [sns-ca-notifications](#module\_sns-ca-notifications) | ./modules/terraform-aws-ca-sns | n/a |
+| <a name="module_sns_ca_notifications"></a> [sns\_ca\_notifications](#module\_sns\_ca\_notifications) | ./modules/terraform-aws-ca-sns | n/a |
 | <a name="module_step-function"></a> [step-function](#module\_step-function) | ./modules/terraform-aws-ca-step-function | n/a |
 | <a name="module_step-function-role"></a> [step-function-role](#module\_step-function-role) | ./modules/terraform-aws-ca-iam | n/a |
 | <a name="module_tls_keygen_iam"></a> [tls\_keygen\_iam](#module\_tls\_keygen\_iam) | ./modules/terraform-aws-ca-iam | n/a |
@@ -67,7 +67,7 @@
 | <a name="input_issuing_crl_days"></a> [issuing\_crl\_days](#input\_issuing\_crl\_days) | Number of days before Issuing CA CRL expires, in addition to seconds. Must be greater than or equal to Step Function interval | `number` | `1` | no |
 | <a name="input_issuing_crl_seconds"></a> [issuing\_crl\_seconds](#input\_issuing\_crl\_seconds) | Number of seconds before Issuing CA CRL expires, in addition to days. Used for overlap in case of clock skew | `number` | `600` | no |
 | <a name="input_kms_arn_resource"></a> [kms\_arn\_resource](#input\_kms\_arn\_resource) | KMS key ARN used for general resource encryption, different from key used for CA key protection | `string` | `""` | no |
-| <a name="input_kms_key_alias"></a> [kms\_key\_alias](#input\_kms\_key\_alias) | KMS key alias for bucket encryption, if left at default, TLS key gen KMS key will be used | `string` | `""` | no |
+| <a name="input_kms_key_alias"></a> [kms\_key\_alias](#input\_kms\_key\_alias) | KMS key alias for bucket encryption with key rotation disabled, if left at default, TLS key gen KMS key will be used | `string` | `""` | no |
 | <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | Name of log bucket, if access\_logs variable set to true | `string` | `""` | no |
 | <a name="input_logging_account_id"></a> [logging\_account\_id](#input\_logging\_account\_id) | AWS Account ID of central logging account for CloudWatch subscription filters | `string` | `""` | no |
 | <a name="input_max_cert_lifetime"></a> [max\_cert\_lifetime](#input\_max\_cert\_lifetime) | Maximum end entity certificate lifetime in days | `number` | `365` | no |

--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ module "tls_keygen_iam" {
   policy                 = "tls_cert"
   external_s3_bucket_arn = module.external_s3.s3_bucket_arn
   internal_s3_bucket_arn = module.internal_s3.s3_bucket_arn
-  sns_topic_arn          = module.sns-ca-notifications.sns_topic_arn
+  sns_topic_arn          = module.sns_ca_notifications.sns_topic_arn
 }
 
 module "create_rsa_root_ca_lambda" {
@@ -191,7 +191,7 @@ module "create_rsa_root_ca_lambda" {
   domain                          = var.hosted_zone_domain
   runtime                         = var.runtime
   public_crl                      = var.public_crl
-  sns_topic_arn                   = module.sns-ca-notifications.sns_topic_arn
+  sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
 }
 
 module "create_rsa_issuing_ca_lambda" {
@@ -212,7 +212,7 @@ module "create_rsa_issuing_ca_lambda" {
   domain                          = var.hosted_zone_domain
   runtime                         = var.runtime
   public_crl                      = var.public_crl
-  sns_topic_arn                   = module.sns-ca-notifications.sns_topic_arn
+  sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
 }
 
 module "rsa_root_ca_crl_lambda" {
@@ -235,7 +235,7 @@ module "rsa_root_ca_crl_lambda" {
   domain                          = var.hosted_zone_domain
   runtime                         = var.runtime
   public_crl                      = var.public_crl
-  sns_topic_arn                   = module.sns-ca-notifications.sns_topic_arn
+  sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
 }
 
 module "rsa_issuing_ca_crl_lambda" {
@@ -258,7 +258,7 @@ module "rsa_issuing_ca_crl_lambda" {
   domain                          = var.hosted_zone_domain
   runtime                         = var.runtime
   public_crl                      = var.public_crl
-  sns_topic_arn                   = module.sns-ca-notifications.sns_topic_arn
+  sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
 }
 
 module "rsa_tls_cert_lambda" {
@@ -281,7 +281,7 @@ module "rsa_tls_cert_lambda" {
   public_crl                      = var.public_crl
   max_cert_lifetime               = var.max_cert_lifetime
   allowed_invocation_principals   = var.aws_principals
-  sns_topic_arn                   = module.sns-ca-notifications.sns_topic_arn
+  sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
 }
 
 module "cloudfront_certificate" {
@@ -376,7 +376,7 @@ module "db-reader-role" {
   assume_role_policy = "db_reader"
 }
 
-module "sns-ca-notifications" {
+module "sns_ca_notifications" {
   source = "./modules/terraform-aws-ca-sns"
 
   project                       = var.project

--- a/modules/terraform-aws-ca-kms/main.tf
+++ b/modules/terraform-aws-ca-kms/main.tf
@@ -1,7 +1,7 @@
 resource "aws_kms_key" "encryption" {
   description             = var.description == "" ? local.key_description : var.description
   deletion_window_in_days = 7
-  enable_key_rotation     = var.customer_master_key_spec == "SYMMETRIC_DEFAULT" ? true : false
+  enable_key_rotation     = var.enable_key_rotation
   policy = templatefile("${path.module}/templates/${var.kms_policy}.json.tpl", {
     account_id = data.aws_caller_identity.current.account_id,
     region     = data.aws_region.current.name

--- a/modules/terraform-aws-ca-kms/variables.tf
+++ b/modules/terraform-aws-ca-kms/variables.tf
@@ -5,6 +5,11 @@ variable "description" {
   default     = ""
 }
 
+variable "enable_key_rotation" {
+  description = "enable key rotation"
+  default     = false # must be false for asymmetric keys, and symmetric keys used for S3 encryption with long-lived content
+}
+
 variable "env" {
   description = "Environment name, e.g. dev"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,6 @@ output "root_ca_crl_s3_location" {
 }
 
 output "sns_topic_arn" {
-  value       = module.sns-ca-notifications.sns_topic_arn
+  value       = module.sns_ca_notifications.sns_topic_arn
   description = "SNS topic ARN"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ variable "issuing_crl_seconds" {
 }
 
 variable "kms_key_alias" {
-  description = "KMS key alias for bucket encryption, if left at default, TLS key gen KMS key will be used"
+  description = "KMS key alias for bucket encryption with key rotation disabled, if left at default, TLS key gen KMS key will be used"
   default     = ""
 }
 


### PR DESCRIPTION
- disable key rotation for the symmetric key used for S3 bucket encryption, this is to avoid the CA failing after 1 year when it would then be unable to decrypt older S3 objects
- update module naming for SNS, this will cause deletion and recreation of the SNS topic, so any subscriptions will have to be set up again
