### PR TITLE
source with dot replaced. Py venv errors processing added

### DIFF
--- a/modules/terraform-aws-ca-lambda/scripts/lambda-build/create-package.sh
+++ b/modules/terraform-aws-ca-lambda/scripts/lambda-build/create-package.sh
@@ -21,8 +21,18 @@ dir_name=$function_name/
 mkdir -p $path_cwd/build/$dir_name
 
 # Create and activate virtual environment...
-python3 -m venv $path_cwd/build/env_$function_name
-source $path_cwd/build/env_$function_name/bin/activate
+if ! python3 -m venv $path_cwd/build/env_$function_name; then
+  echo "Error: Python virtual environment creation failed"
+  exit 1
+else
+  echo "Python virtual environment created"
+fi
+if ! . $path_cwd/build/env_$function_name/bin/activate; then
+  echo "Error: Python virtual environment activation failed"
+  exit 1
+else
+  echo "Python virtual environment activated"
+fi
 
 # Installing python dependencies...
 FILE=$path_cwd/lambda_code/$function_name/requirements.txt


### PR DESCRIPTION
I suggest using **dot** instead of **source** to provide safe portability according to the POSIX standard (IEEE Std 1003.1-2024).

Adding **exit 1** in case of python venv activation failure fails local-exec provisioner. This will stop resource creation and prevent Lambda from being uploaded without the modules described in the requirements.