### PR TITLE
Support wildcard SANs and log invalid SANs

### DIFF
--- a/modules/terraform-aws-ca-lambda/unittests/test_validate_sans.py
+++ b/modules/terraform-aws-ca-lambda/unittests/test_validate_sans.py
@@ -31,3 +31,11 @@ def test_filter_and_validate_sans_wildcard_disallowed_if_base_domain_invalid():
     expected = ["example.com", "example.org"]
 
     assert output == expected
+
+
+def test_filter_and_validate_sans_mixed_domains():
+    sans = ["example.com", "example.org", "*.example.net", "*.net", "Invalid DNS name"]
+    output = filter_and_validate_sans("example.com", sans)
+    expected = ["example.com", "example.org", "*.example.net"]
+
+    assert output == expected

--- a/modules/terraform-aws-ca-lambda/unittests/test_validate_sans.py
+++ b/modules/terraform-aws-ca-lambda/unittests/test_validate_sans.py
@@ -1,0 +1,33 @@
+from utils.certs.types import filter_and_validate_sans
+
+
+def test_filter_and_validate_sans():
+    input = ["example.com", "example.org", "example.net"]
+    output = filter_and_validate_sans("example.com", input)
+    expected = ["example.com", "example.org", "example.net"]
+
+    assert output == expected
+
+
+def test_filter_and_validate_sans_invalid_domain():
+    input = ["example.com", "example.org", "net"]
+    output = filter_and_validate_sans("example.com", input)
+    expected = ["example.com", "example.org"]
+
+    assert output == expected
+
+
+def test_filter_and_validate_sans_wildcard_allowed():
+    input = ["example.com", "example.org", "*.example.net"]
+    output = filter_and_validate_sans("example.com", input)
+    expected = ["example.com", "example.org", "*.example.net"]
+
+    assert output == expected
+
+
+def test_filter_and_validate_sans_wildcard_disallowed_if_base_domain_invalid():
+    input = ["example.com", "example.org", "*.net"]
+    output = filter_and_validate_sans("example.com", input)
+    expected = ["example.com", "example.org"]
+
+    assert output == expected

--- a/modules/terraform-aws-ca-lambda/unittests/test_validate_sans.py
+++ b/modules/terraform-aws-ca-lambda/unittests/test_validate_sans.py
@@ -2,32 +2,32 @@ from utils.certs.types import filter_and_validate_sans
 
 
 def test_filter_and_validate_sans():
-    input = ["example.com", "example.org", "example.net"]
-    output = filter_and_validate_sans("example.com", input)
+    sans = ["example.com", "example.org", "example.net"]
+    output = filter_and_validate_sans("example.com", sans)
     expected = ["example.com", "example.org", "example.net"]
 
     assert output == expected
 
 
 def test_filter_and_validate_sans_invalid_domain():
-    input = ["example.com", "example.org", "net"]
-    output = filter_and_validate_sans("example.com", input)
+    sans = ["example.com", "example.org", "net"]
+    output = filter_and_validate_sans("example.com", sans)
     expected = ["example.com", "example.org"]
 
     assert output == expected
 
 
 def test_filter_and_validate_sans_wildcard_allowed():
-    input = ["example.com", "example.org", "*.example.net"]
-    output = filter_and_validate_sans("example.com", input)
+    sans = ["example.com", "example.org", "*.example.net"]
+    output = filter_and_validate_sans("example.com", sans)
     expected = ["example.com", "example.org", "*.example.net"]
 
     assert output == expected
 
 
 def test_filter_and_validate_sans_wildcard_disallowed_if_base_domain_invalid():
-    input = ["example.com", "example.org", "*.net"]
-    output = filter_and_validate_sans("example.com", input)
+    sans = ["example.com", "example.org", "*.net"]
+    output = filter_and_validate_sans("example.com", sans)
     expected = ["example.com", "example.org"]
 
     assert output == expected

--- a/modules/terraform-aws-ca-lambda/utils/certs/types.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/types.py
@@ -81,16 +81,17 @@ def filter_and_validate_sans(common_name: str, sans: list[str]) -> list[str]:
     if (_sans is None or _sans == []) and valid_common_name:
         _sans = [common_name]
 
-    # remove invalid SANs
+    # log invalid SANs
     for san in _sans:
         # allow wildcard SANs provided base domain is valid
         if san.split(".")[0] == "*" and domain_validator(san[2:]):
             continue
-
-        # remove invalid SANs
+        # log invalid SANs
         if not domain_validator(san):
-            _sans.remove(san)
             print(f"Invalid domain {san} excluded from SANs")
+
+    # remove invalid SANs
+    _sans = [s for s in _sans if domain_validator(s) or s.split(".")[0] == "*" and domain_validator(s[2:])]
 
     return _sans
 

--- a/modules/terraform-aws-ca-lambda/utils/certs/types.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/types.py
@@ -82,7 +82,15 @@ def filter_and_validate_sans(common_name: str, sans: list[str]) -> list[str]:
         _sans = [common_name]
 
     # remove invalid SANs
-    _sans = [s for s in _sans if domain_validator(s)]
+    for san in _sans:
+        # allow wildcard SANs provided base domain is valid
+        if san.split(".")[0] == "*" and domain_validator(san[2:]):
+            continue
+
+        # remove invalid SANs
+        if not domain_validator(san):
+            _sans.remove(san)
+            print(f"Invalid domain {san} excluded from SANs")
 
     return _sans
 

--- a/tests/test_issued_certs.py
+++ b/tests/test_issued_certs.py
@@ -19,7 +19,6 @@ from utils.modules.certs.crypto import (
 )
 
 from utils.modules.aws.kms import get_kms_details
-from utils.modules.aws.lambdas import get_lambda_name, invoke_lambda
 from utils.modules.aws.s3 import delete_s3_object, get_s3_bucket, list_s3_object_keys, put_s3_object
 from .helper import (
     helper_create_csr_info,
@@ -148,8 +147,8 @@ def test_issued_cert_includes_correct_dns_names():
     Test issued certificate contains correct DNS names in Subject Alternative Name extension
     """
     common_name = "pipeline-test-dn-csr-no-passphrase.example.com"
-    sans = ["test1.example.com", "test2.example.com", "invalid DNS name"]
-    expected_result = ["test1.example.com", "test2.example.com"]
+    sans = ["test1.example.com", "test2.example.com", "*.example.com", "*.com", "invalid DNS name"]
+    expected_result = ["test1.example.com", "test2.example.com", "*.example.com"]
 
     purposes = ["server_auth"]
 


### PR DESCRIPTION
- support a wildcard SAN, e.g. `*.example.com`
- continue to check domain is valid before including in SANs
- create a CloudWatch log entry if a domain has been rejected because it's invalid