### PR TITLE
utils scripts enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ terraform.tfvars
 
 # MacOS
 .DS_Store
+
+# Vim
+**.swp

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ modules/terraform-aws-ca-lambda/build/
 # Python
 __pycache__
 .venv
+.python-version
+**/pyvenv.cfg
+**/bin
+**/lib
+**/lib64
 
 # Terraform
 .terraform/

--- a/utils/client-cert.py
+++ b/utils/client-cert.py
@@ -71,18 +71,14 @@ def main():  # pylint:disable=too-many-locals
     # create AWS session
     session = get_session(profile)
     if isinstance(session, dict):
-        print(
-            f'Error: Unable to open session using profile {profile_name}. {session["error"]}'
-        )
+        print(f'Error: Unable to open session using profile {profile_name}. {session["error"]}')
     else:
         print(f"AWS session opened using profile: {profile_name}")
 
     # set variables
     variables = parse_variables(client_template)
     if "error" in variables:
-        print(
-            f'Error: Unable to read variables. Error reported is: {variables["error"]}'
-        )
+        print(f'Error: Unable to read variables. Error reported is: {variables["error"]}')
     else:
         print(f"Variables are obtained from file {client_template}")
 
@@ -109,9 +105,7 @@ def main():  # pylint:disable=too-many-locals
     private_key = load_der_private_key(kms_response["PrivateKeyPlaintext"], None)
 
     # create CSR
-    csr_info = create_csr_info(
-        common_name, country, locality, organization, organizational_unit, state
-    )
+    csr_info = create_csr_info(common_name, country, locality, organization, organizational_unit, state)
     csr_pem = crypto_tls_cert_signing_request(private_key, csr_info)
 
     # Construct JSON data to pass to Lambda function
@@ -167,9 +161,7 @@ def main():  # pylint:disable=too-many-locals
         with open(output_path_cert_combined, "w", encoding="utf-8") as f:
             f.write(key_data.decode("utf-8"))
             f.write(cert_data.decode("utf-8"))
-            print(
-                f"Combined root and intermediate bundle written to {output_path_cert_combined}"
-            )
+            print(f"Combined root and intermediate bundle written to {output_path_cert_combined}")
 
 
 if __name__ == "__main__":

--- a/utils/client-cert.py
+++ b/utils/client-cert.py
@@ -24,7 +24,10 @@ def create_session(profile):
     """
 
     try:
-        session = boto3.session.Session(profile_name=profile)
+        if profile is not None:
+            session = boto3.session.Session(profile_name=profile)
+        else:
+            session = boto3.session.Session()
     except Exception as e:
         session = {"error": e}
     if isinstance(session, dict):
@@ -42,7 +45,7 @@ def parse_arguments():
 
     arguments = {}
     parser = argparse.ArgumentParser()
-    parser.add_argument("--profile", default="default", help="AWS profile described in .aws/config file")
+    parser.add_argument("--profile", default=None, help="AWS profile described in .aws/config file")
     parser.add_argument("--verbose", action="store_true", help="Output of all generated payload data")
     arguments = vars(parser.parse_args())
 
@@ -57,8 +60,7 @@ def main():  # pylint:disable=too-many-locals,too-many-statements
     args = parse_arguments()
 
     # create AWS session
-    profile_name = args["profile"]
-    session = create_session(profile_name)
+    session = create_session(args["profile"])
 
     # set variables
     lifetime = 90

--- a/utils/client-cert.py
+++ b/utils/client-cert.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import json
 import base64
-import boto3
 import os
+import sys
+import argparse
+import boto3
 from cryptography.hazmat.primitives.serialization import load_der_private_key
 from modules.certs.crypto import create_csr_info, crypto_encode_private_key, crypto_tls_cert_signing_request
 from modules.certs.kms import kms_generate_key_pair, kms_get_kms_key_id
@@ -10,35 +12,89 @@ from modules.aws.lambdas import get_lambda_name
 
 # identify home directory and create certs subdirectory if needed
 homedir = os.path.expanduser("~")
-base_path = f"{homedir}/certs"
+dir_path = os.path.dirname(os.path.realpath(__file__))
+templatesdir = f'{dir_path}/templates'
+base_path = f"{homedir}/ca/client_certificates"
+client_template = f'{templatesdir}/client_certificate_variables.json'
 if not os.path.exists(base_path):
     print(f"Creating directory {base_path}")
     os.makedirs(base_path)
 
+def parse_variables(input_file):
+    """
+    Parse template file to obtain variables
+    """
+
+    if os.path.isfile(input_file):
+        try:
+            with open(input_file, encoding="utf-8") as json_file:
+                data = json.load(json_file)
+        except Exception as e:
+            data = {"error": f'Unable to parse JSON. {e}'}
+    else:
+        data = {"error": "No file"}
+    return data
+
+def get_session(aws_profile):
+    """
+    Open boto3 connection using profile
+    """
+
+    try:
+        aws_session = boto3.session.Session(profile_name=aws_profile)
+    except Exception as e:
+        aws_session = {"error": e}
+    return aws_session
 
 def main():  # pylint:disable=too-many-locals
     """
     Create test client certificate for default Serverless CA environment
     """
 
+    # parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", help="AWS profile described in .aws/config file")
+    args = parser.parse_args()
+    profile = vars(args)["profile"]
+    if profile is None:
+        profile_name = "default"
+    else:
+        profile_name = profile
+
+    # create AWS session
+    session = get_session(profile)
+    if isinstance(session, dict):
+        print(f'Error: Unable to open session using profile {profile_name}. Error reported is: {session["error"]}')
+    else:
+        print(f'AWS session opened using profile: {profile_name}')
+
     # set variables
-    lifetime = 90
-    common_name = "My Test Certificate"
-    country = "GB"
-    locality = "London"
-    state = "England"
-    organization = "Serverless Inc"
-    organizational_unit = "Security Operations"
-    purposes = ["client_auth"]
+    variables = parse_variables(client_template)
+    if "error" in variables:
+        print(f'Error: Unable to read variables. Error reported is: {variables["error"]}')
+    else:
+        print(f'Variables are obtained from file {client_template}')
+
+    lifetime = variables["lifetime"]
+    common_name = variables["common_name"]
+    country = variables["country"]
+    locality = variables["locality"]
+    state = variables["state"]
+    organization = variables["organization"]
+    organizational_unit = variables["organizational_unit"]
+    purposes = variables["purposes"]
     output_path_cert_key = f"{base_path}/client-key.pem"
-    output_path_cert_pem = f"{base_path}/client-cert.pem"
+    output_path_cert_pem = f"{base_path}/issuer-bundle.pem"
     output_path_cert_crt = f"{base_path}/client-cert.crt"
-    output_path_cert_combined = f"{base_path}/client-cert-key.pem"
-    key_alias = "serverless-tls-keygen-dev"
+    output_path_cert_combined = f"{base_path}/ca-bundle.pem"
+    key_alias = variables["key_alias"]
 
     # create key pair using symmetric KMS key to provide entropy
-    key_id = kms_get_kms_key_id(key_alias)
-    kms_response = kms_generate_key_pair(key_id)
+    key_id = kms_get_kms_key_id(key_alias, session=session)
+    if isinstance(key_id, dict):
+        print(f'Error: {key_id["error"]}')
+        sys.exit(1)
+    kms_response = kms_generate_key_pair(key_id, session=session)
     private_key = load_der_private_key(kms_response["PrivateKeyPlaintext"], None)
 
     # create CSR
@@ -58,8 +114,8 @@ def main():  # pylint:disable=too-many-locals
     request_payload_bytes = json.dumps(request_payload)
 
     # Invoke TLS certificate Lambda function
-    lambda_name = get_lambda_name("tls-cert")
-    client = boto3.client("lambda")
+    lambda_name = get_lambda_name("tls-cert", session=session)
+    client = session.client("lambda")
     response = client.invoke(
         FunctionName=lambda_name,
         InvocationType="RequestResponse",
@@ -87,7 +143,7 @@ def main():  # pylint:disable=too-many-locals
     if output_path_cert_pem:
         with open(output_path_cert_pem, "w", encoding="utf-8") as f:
             f.write(cert_data.decode("utf-8"))
-            print(f"Certificate written to {output_path_cert_pem}")
+            print(f"Intermediate bundle written to {output_path_cert_pem}")
 
     if output_path_cert_crt:
         with open(output_path_cert_crt, "w", encoding="utf-8") as f:
@@ -98,8 +154,7 @@ def main():  # pylint:disable=too-many-locals
         with open(output_path_cert_combined, "w", encoding="utf-8") as f:
             f.write(key_data.decode("utf-8"))
             f.write(cert_data.decode("utf-8"))
-
-    print(f"Certificate and key written to {output_path_cert_combined}")
+            print(f"Combined root and intermediate bundle written to {output_path_cert_combined}")
 
 
 if __name__ == "__main__":

--- a/utils/generate-cert.py
+++ b/utils/generate-cert.py
@@ -36,16 +36,21 @@ def parse_variables(input_file):
     return data
 
 
-def get_session(aws_profile):
+def create_session(profile):
     """
-    Open boto3 connection using profile
+    Creates and returns AWS session using profile
     """
 
     try:
-        aws_session = boto3.session.Session(profile_name=aws_profile)
+        session = boto3.session.Session(profile_name=profile)
     except Exception as e:
-        aws_session = {"error": e}
-    return aws_session
+        session = {"error": e}
+    if isinstance(session, dict):
+        print(f"Error: Unable to open session using profile {profile}. {session['error']}")
+        sys.exit(1)
+    else:
+        print(f"AWS session opened using profile: {profile}")
+    return session
 
 
 def parse_arguments():
@@ -66,21 +71,6 @@ def parse_arguments():
     arguments = vars(parser.parse_args())
 
     return arguments
-
-
-def create_session(profile):
-    """
-    Creates and returns AWS session using profile
-    """
-
-    session = get_session(profile)
-    if isinstance(session, dict):
-        print(f"Error: Unable to open session using profile {profile}. {session['error']}")
-        sys.exit(1)
-    else:
-        print(f"AWS session opened using profile: {profile}")
-
-    return session
 
 
 def get_first_certificate(data):

--- a/utils/generate-cert.py
+++ b/utils/generate-cert.py
@@ -62,7 +62,7 @@ def parse_arguments():
     parser.add_argument("--keyalgo", default=default_key_pair_spec, help="Key algorithm")
     parser.add_argument("--destination", default=default_base_path, help="Destination directory for generated keys")
     parser.add_argument("--keygenalias", default=None, help="Alias for KMS key")
-    parser.add_argument("--verbose", action="store_true", help="Output all generated payload data")
+    parser.add_argument("--verbose", action="store_true", help="Output of all generated payload data")
     arguments = vars(parser.parse_args())
 
     return arguments

--- a/utils/generate-cert.py
+++ b/utils/generate-cert.py
@@ -15,7 +15,7 @@ from modules.aws.lambdas import get_lambda_name
 homedir = os.path.expanduser("~")
 dir_path = os.path.dirname(os.path.realpath(__file__))
 default_vardir = f"{dir_path}/variables"
-default_varfile = "certificate_variables.json"
+default_varfile = "client.json"
 default_base_path = f"{homedir}/ca/certificates"
 default_key_pair_spec = "ECC_NIST_P256"
 

--- a/utils/generate-cert.py
+++ b/utils/generate-cert.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+
+import json
+import base64
+import os
+import sys
+import argparse
+import boto3
+from cryptography.hazmat.primitives.serialization import load_der_private_key
+from modules.certs.crypto import create_csr_info, crypto_encode_private_key, crypto_tls_cert_signing_request
+from modules.certs.kms import kms_generate_key_pair, kms_get_kms_key_id
+from modules.aws.lambdas import get_lambda_name
+
+# identify home directory and create certs subdirectory if needed
+homedir = os.path.expanduser("~")
+dir_path = os.path.dirname(os.path.realpath(__file__))
+default_vardir = f"{dir_path}/variables"
+default_varfile = "certificate_variables.json"
+default_base_path = f"{homedir}/ca/certificates"
+default_key_pair_spec = "ECC_NIST_P256"
+
+
+def parse_variables(input_file):
+    """
+    Parse variables file to obtain variables
+    """
+
+    if os.path.isfile(input_file):
+        try:
+            with open(input_file, encoding="utf-8") as json_file:
+                data = json.load(json_file)
+        except Exception as e:
+            data = {"error": f"Unable to parse JSON. {e}"}
+    else:
+        data = {"error": "No file"}
+    return data
+
+
+def get_session(aws_profile):
+    """
+    Open boto3 connection using profile
+    """
+
+    try:
+        aws_session = boto3.session.Session(profile_name=aws_profile)
+    except Exception as e:
+        aws_session = {"error": e}
+    return aws_session
+
+
+def parse_arguments():
+    """
+    Read arguments and return arguments dictonary
+    """
+
+    arguments = {}
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--server", action="store_true", help="The role for which the certificate is being generated")
+    parser.add_argument("--profile", default="default", help="AWS profile described in .aws/config file")
+    parser.add_argument("--vardir", default=default_vardir, help="Directory with JSON files with variables")
+    parser.add_argument("--varfile", default=default_varfile, help="JSON variables file")
+    parser.add_argument("--keyalgo", default=default_key_pair_spec, help="Key algorithm")
+    parser.add_argument("--destination", default=default_base_path, help="Destination directory for generated keys")
+    parser.add_argument("--keygenalias", default=None, help="Alias for KMS key")
+    parser.add_argument("--verbose", action="store_true", help="Output all generated payload data")
+    arguments = vars(parser.parse_args())
+
+    return arguments
+
+
+def create_session(profile):
+    """
+    Creates and returns AWS session using profile
+    """
+
+    session = get_session(profile)
+    if isinstance(session, dict):
+        print(f"Error: Unable to open session using profile {profile}. {session['error']}")
+        sys.exit(1)
+    else:
+        print(f"AWS session opened using profile: {profile}")
+
+    return session
+
+
+def get_first_certificate(data):
+    """
+    Leave only the first certificate
+    """
+
+    certs = data.split("-----END CERTIFICATE-----")
+    certs = [cert.strip() + "\n-----END CERTIFICATE-----" for cert in certs if cert.strip()]
+    if certs:
+        return certs[0]
+    return None
+
+
+def main():  # pylint:disable=too-many-locals,too-many-branches,too-many-statements
+    """
+    Create certificate for default Serverless CA environment
+    """
+
+    args = parse_arguments()
+
+    varfile = f"{args['vardir']}/{args['varfile']}"
+    is_server = args["server"]
+    if is_server:
+        role = "server"
+        print("Generating SERVER certificate")
+    else:
+        role = "client"
+        print("Generating CLIENT certificate")
+    base_path = args["destination"]
+    if not os.path.exists(base_path):
+        print(f"Creating directory {base_path}")
+        os.makedirs(base_path)
+
+    session = create_session(args["profile"])
+
+    # set variables
+    variables = parse_variables(varfile)
+    if "error" in variables:
+        print(f'Error: Unable to read variables. {variables["error"]}')
+    else:
+        print(f"Variables are obtained from file {varfile}")
+
+    lifetime = variables["lifetime"]
+    common_name = variables["common_name"]
+    country = variables["country"]
+    locality = variables["locality"]
+    state = variables["state"]
+    organization = variables["organization"]
+    organizational_unit = variables["organizational_unit"]
+    purposes = variables["purposes"]
+    if args["keygenalias"] is None:
+        key_alias = variables["key_alias"]
+    else:
+        key_alias = args["keygenalias"]
+    if is_server:
+        try:
+            sans = variables["sans"]
+        except KeyError:
+            print("Server role requires sans variable to be set, but it is not obtained")
+            sys.exit(3)
+
+    # create key pair using symmetric KMS key to provide entropy
+    key_id = kms_get_kms_key_id(key_alias, session=session)
+    if isinstance(key_id, dict):
+        print(f'Error: {key_id["error"]}')
+        sys.exit(1)
+    kms_response = kms_generate_key_pair(key_id, key_pair_spec=args["keyalgo"], session=session)
+    private_key = load_der_private_key(kms_response["PrivateKeyPlaintext"], None)
+
+    # create CSR
+    csr_info = create_csr_info(common_name, country, locality, organization, organizational_unit, state)
+    csr_pem = crypto_tls_cert_signing_request(private_key, csr_info)
+
+    # Construct JSON data to pass to Lambda function
+    request_payload = {
+        "common_name": common_name,
+        "purposes": purposes,
+        "lifetime": lifetime,
+        "base64_csr_data": base64.b64encode(csr_pem).decode("utf-8"),
+        "force_issue": True,
+        "cert_bundle": True,
+    }
+    if is_server:
+        request_payload["sans"] = sans
+
+    request_payload_bytes = json.dumps(request_payload)
+
+    # Invoke TLS certificate Lambda function
+    lambda_name = get_lambda_name("tls-cert", session=session)
+    client = session.client("lambda")
+    response = client.invoke(
+        FunctionName=lambda_name,
+        InvocationType="RequestResponse",
+        LogType="None",
+        Payload=bytes(request_payload_bytes.encode("utf-8")),
+    )
+
+    # Inspect the response which includes the signed certificate
+    response_payload = response["Payload"]
+    payload_data = json.load(response_payload)
+    print(f"Certificate issued for {common_name}")
+    if args["verbose"]:
+        print(payload_data)
+
+    # Extract certificate and private key from response
+    base64_cert_data = payload_data["Base64Certificate"]
+    cert_data = base64.b64decode(base64_cert_data)
+    key_data = crypto_encode_private_key(private_key)
+
+    # Creating per certificate directory
+    clean_common_name = common_name.split(".")[0]
+    certificate_dir = f"{base_path}/{clean_common_name}"
+    if not os.path.exists(certificate_dir):
+        print(f"Creating per certificate directory {clean_common_name}")
+        os.makedirs(certificate_dir)
+
+    # Set outputs destination
+    output_path_cert_key = f"{certificate_dir}/{role}-key.pem"  # private key
+    output_path_cert_crt = f"{certificate_dir}/{role}-cert.crt"  # certificate
+    output_path_cert_pem = f"{certificate_dir}/ca.pem"  # cert + issuing CA + root CA PEM bundle
+
+    # Get the first certificate from cert_data
+    first_cert = get_first_certificate(cert_data.decode("utf-8"))
+    if first_cert is None:
+        cert = cert_data.decode("utf-8")
+    else:
+        cert = first_cert
+
+    # Write certificate and private key to files
+    if output_path_cert_key:
+        with open(output_path_cert_key, "w", encoding="utf-8") as f:
+            f.write(key_data.decode("utf-8"))
+            print(f"Private key written to {output_path_cert_key}")
+
+    if output_path_cert_pem:
+        with open(output_path_cert_pem, "w", encoding="utf-8") as f:
+            f.write(cert_data.decode("utf-8"))
+            print(f"Intermediate CA pem bundle written to {output_path_cert_pem}")
+
+    if output_path_cert_crt:
+        with open(output_path_cert_crt, "w", encoding="utf-8") as f:
+            f.write(cert)
+            print(f"Certificate written to {output_path_cert_crt}")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/generate-cert.py
+++ b/utils/generate-cert.py
@@ -194,7 +194,7 @@ def write_certificate_files(cert_data, key_data, common_name, base_path, is_serv
 
     with open(output_path_cert_pem, "w", encoding="utf-8") as f:
         f.write(cert_data.decode("utf-8"))
-        print(f"Intermediate CA pem bundle written to {output_path_cert_pem}")
+        print(f"Certificate chain written to {output_path_cert_pem}")
 
     cert = get_first_certificate(cert_data.decode("utf-8")) or cert_data.decode("utf-8")
     with open(output_path_cert_crt, "w", encoding="utf-8") as f:

--- a/utils/modules/aws/kms.py
+++ b/utils/modules/aws/kms.py
@@ -1,12 +1,14 @@
 import boto3
 
 
-def get_kms_details(key_purpose):
+def get_kms_details(key_purpose, session=None):
     """
     Get the KMS ARN based on the key purpose
     """
-
-    kms_client = boto3.client("kms")
+    if session is None:
+        kms_client = boto3.client("kms")
+    else:
+        kms_client = session.client("kms")
 
     key_aliases = kms_client.list_aliases()["Aliases"]
     key_aliases = [k for k in key_aliases if key_purpose in k["AliasName"]]

--- a/utils/modules/aws/lambdas.py
+++ b/utils/modules/aws/lambdas.py
@@ -2,12 +2,14 @@ import boto3
 import json
 
 
-def get_lambda_name(lambda_purpose):
+def get_lambda_name(lambda_purpose, session=None):
     """
     Get the full name of the Lambda function based on its purpose
     """
-
-    lambda_client = boto3.client("lambda")
+    if session is None:
+        lambda_client = boto3.client("lambda")
+    else:
+        lambda_client = session.client("lambda")
 
     lambdas = lambda_client.list_functions()["Functions"]
     lambdas = [la for la in lambdas if lambda_purpose in la["FunctionName"]]
@@ -15,12 +17,15 @@ def get_lambda_name(lambda_purpose):
     return lambdas[0]["FunctionName"]
 
 
-def invoke_lambda(function_name, json_data):
+def invoke_lambda(function_name, json_data, session=None):
     """
     Invoke TLS certificate Lambda function
     """
 
-    lambda_client = boto3.client("lambda")
+    if session is None:
+        lambda_client = boto3.client("lambda")
+    else:
+        lambda_client = session.client("lambda")
 
     response = lambda_client.invoke(
         FunctionName=function_name,

--- a/utils/modules/aws/s3.py
+++ b/utils/modules/aws/s3.py
@@ -47,7 +47,9 @@ def get_s3_object(bucket_name, key, session=None):
     return response["Body"].read()
 
 
-def put_s3_object(bucket_name, kms_arn, key, data, encryption_algorithm="aws:kms", session=None): # pylint:disable=too-many-arguments,too-many-positional-arguments
+def put_s3_object(
+    bucket_name, kms_arn, key, data, encryption_algorithm="aws:kms", session=None
+):  # pylint:disable=too-many-arguments,too-many-positional-arguments
     """
     Put object in S3 bucket
     """

--- a/utils/modules/aws/s3.py
+++ b/utils/modules/aws/s3.py
@@ -47,7 +47,7 @@ def get_s3_object(bucket_name, key, session=None):
     return response["Body"].read()
 
 
-def put_s3_object(bucket_name, kms_arn, key, data, encryption_algorithm="aws:kms", session=None):
+def put_s3_object(bucket_name, kms_arn, key, data, encryption_algorithm="aws:kms", session=None): # pylint:disable=too-many-arguments,too-many-positional-arguments
     """
     Put object in S3 bucket
     """

--- a/utils/modules/aws/s3.py
+++ b/utils/modules/aws/s3.py
@@ -1,22 +1,30 @@
 import boto3
 
 
-def get_s3_bucket(bucket_purpose="internal"):
+def get_s3_bucket(bucket_purpose="internal", session=None):
     """
     Get the full name of the S3 bucket based on its purpose
     """
 
-    s3_client = boto3.client("s3")
+    if session is None:
+        s3_client = boto3.client("s3")
+    else:
+        s3_client = session.client("s3")
+
     s3_buckets = s3_client.list_buckets()["Buckets"]
     return [b["Name"] for b in s3_buckets if f"-{bucket_purpose}-" in b["Name"]][0]
 
 
-def list_s3_object_keys(bucket_name):
+def list_s3_object_keys(bucket_name, session=None):
     """
     List object keys in S3 bucket
     """
 
-    s3_client = boto3.client("s3")
+    if session is None:
+        s3_client = boto3.client("s3")
+    else:
+        s3_client = session.client("s3")
+
     response = s3_client.list_objects_v2(Bucket=bucket_name)
 
     s3_objects = response["Contents"]
@@ -24,32 +32,44 @@ def list_s3_object_keys(bucket_name):
     return [s3_object["Key"] for s3_object in s3_objects]
 
 
-def get_s3_object(bucket_name, key):
+def get_s3_object(bucket_name, key, session=None):
     """
     Get object from S3
     """
 
-    s3_client = boto3.client("s3")
+    if session is None:
+        s3_client = boto3.client("s3")
+    else:
+        s3_client = session.client("s3")
+
     response = s3_client.get_object(Bucket=bucket_name, Key=key)
 
     return response["Body"].read()
 
 
-def put_s3_object(bucket_name, kms_arn, key, data, encryption_algorithm="aws:kms"):
+def put_s3_object(bucket_name, kms_arn, key, data, encryption_algorithm="aws:kms", session=None):
     """
     Put object in S3 bucket
     """
 
-    s3_client = boto3.client("s3")
+    if session is None:
+        s3_client = boto3.client("s3")
+    else:
+        s3_client = session.client("s3")
+
     s3_client.put_object(
         Bucket=bucket_name, SSEKMSKeyId=kms_arn, ServerSideEncryption=encryption_algorithm, Key=key, Body=data
     )
 
 
-def delete_s3_object(bucket_name, key):
+def delete_s3_object(bucket_name, key, session=None):
     """
     Delete object from S3
     """
 
-    s3_client = boto3.client("s3")
+    if session is None:
+        s3_client = boto3.client("s3")
+    else:
+        s3_client = session.client("s3")
+
     s3_client.delete_object(Bucket=bucket_name, Key=key)

--- a/utils/modules/certs/kms.py
+++ b/utils/modules/certs/kms.py
@@ -25,8 +25,9 @@ def kms_get_kms_key_id(alias, session=None):
 
     aliases = client.list_aliases(Limit=100)["Aliases"]
     try:
-        key_id = [a for a in aliases if a["AliasName"] == f"alias/{alias}"][0]["TargetKeyId"]
+        key_id_list = [a for a in aliases if a["AliasName"] == f"alias/{alias}"]
+        key_id = key_id_list[0]["TargetKeyId"]
     except Exception as e:
-        key_id = {"error": f'Failed to get KMS key ID. {e}'}
+        key_id = {"error": f"Failed to get KMS key ID. {e}"}
 
     return key_id

--- a/utils/modules/certs/kms.py
+++ b/utils/modules/certs/kms.py
@@ -1,8 +1,13 @@
 import boto3
 
 
-def kms_generate_key_pair(key_id, key_pair_spec="ECC_NIST_P256"):
-    client = boto3.client(service_name="kms")
+def kms_generate_key_pair(key_id, key_pair_spec="ECC_NIST_P256", session=None):
+    """Generate KMS key pair"""
+
+    if session is None:
+        client = boto3.client(service_name="kms")
+    else:
+        client = session.client(service_name="kms")
 
     return client.generate_data_key_pair(
         KeyId=key_id,
@@ -10,9 +15,18 @@ def kms_generate_key_pair(key_id, key_pair_spec="ECC_NIST_P256"):
     )
 
 
-def kms_get_kms_key_id(alias):
+def kms_get_kms_key_id(alias, session=None):
     """returns the KMS Key ARN for a specified alias"""
-    client = boto3.client(service_name="kms")
-    aliases = client.list_aliases(Limit=100)["Aliases"]
 
-    return [a for a in aliases if a["AliasName"] == f"alias/{alias}"][0]["TargetKeyId"]
+    if session is None:
+        client = boto3.client(service_name="kms")
+    else:
+        client = session.client(service_name="kms")
+
+    aliases = client.list_aliases(Limit=100)["Aliases"]
+    try:
+        key_id = [a for a in aliases if a["AliasName"] == f"alias/{alias}"][0]["TargetKeyId"]
+    except Exception as e:
+        key_id = {"error": f'Failed to get KMS key ID. {e}'}
+
+    return key_id

--- a/utils/server-cert.py
+++ b/utils/server-cert.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
+import os
+import sys
 import json
 import base64
+import argparse
 import boto3
-import os
 from cryptography.hazmat.primitives.serialization import load_der_private_key
 from modules.certs.crypto import create_csr_info, crypto_encode_private_key, crypto_tls_cert_signing_request
 from modules.certs.kms import kms_generate_key_pair, kms_get_kms_key_id
@@ -16,10 +18,47 @@ if not os.path.exists(base_path):
     os.makedirs(base_path)
 
 
-def main():  # pylint:disable=too-many-locals
+def create_session(profile):
     """
-    Create test server certificate for default Serverless CA environment
+    Creates and returns AWS session using profile
     """
+
+    try:
+        session = boto3.session.Session(profile_name=profile)
+    except Exception as e:
+        session = {"error": e}
+    if isinstance(session, dict):
+        print(f"Error: Unable to open session using profile {profile}. {session['error']}")
+        sys.exit(1)
+    else:
+        print(f"AWS session opened using profile: {profile}")
+    return session
+
+
+def parse_arguments():
+    """
+    Read arguments and return arguments dictonary
+    """
+
+    arguments = {}
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", default="default", help="AWS profile described in .aws/config file")
+    parser.add_argument("--verbose", action="store_true", help="Output of all generated payload data")
+    arguments = vars(parser.parse_args())
+
+    return arguments
+
+
+def main():  # pylint:disable=too-many-locals,too-many-statements
+    """
+    Create test client certificate for default Serverless CA environment
+    """
+
+    args = parse_arguments()
+
+    # create AWS session
+    profile_name = args["profile"]
+    session = create_session(profile_name)
 
     # set variables
     lifetime = 90
@@ -38,8 +77,11 @@ def main():  # pylint:disable=too-many-locals
     key_alias = "serverless-tls-keygen-dev"
 
     # create key pair using symmetric KMS key to provide entropy
-    key_id = kms_get_kms_key_id(key_alias)
-    kms_response = kms_generate_key_pair(key_id)
+    key_id = kms_get_kms_key_id(key_alias, session=session)
+    if isinstance(key_id, dict):
+        print(f'Error: {key_id["error"]}')
+        sys.exit(1)
+    kms_response = kms_generate_key_pair(key_id, session=session)
     private_key = load_der_private_key(kms_response["PrivateKeyPlaintext"], None)
 
     # create CSR
@@ -60,8 +102,8 @@ def main():  # pylint:disable=too-many-locals
     request_payload_bytes = json.dumps(request_payload)
 
     # Invoke TLS certificate Lambda function
-    lambda_name = get_lambda_name("tls-cert")
-    client = boto3.client("lambda")
+    lambda_name = get_lambda_name("tls-cert", session=session)
+    client = session.client("lambda")
     response = client.invoke(
         FunctionName=lambda_name,
         InvocationType="RequestResponse",
@@ -73,7 +115,8 @@ def main():  # pylint:disable=too-many-locals
     response_payload = response["Payload"]
     payload_data = json.load(response_payload)
     print(f"Certificate issued for {common_name}")
-    print(payload_data)
+    if args["verbose"]:
+        print(payload_data)
 
     # Extract certificate and private key from response
     base64_cert_data = payload_data["Base64Certificate"]
@@ -89,7 +132,7 @@ def main():  # pylint:disable=too-many-locals
     if output_path_cert_pem:
         with open(output_path_cert_pem, "w", encoding="utf-8") as f:
             f.write(cert_data.decode("utf-8"))
-            print(f"Certificate written to {output_path_cert_pem}")
+            print(f"Combined client certificate and CA bundle written to {output_path_cert_pem}")
 
     if output_path_cert_crt:
         with open(output_path_cert_crt, "w", encoding="utf-8") as f:
@@ -100,8 +143,9 @@ def main():  # pylint:disable=too-many-locals
         with open(output_path_cert_combined, "w", encoding="utf-8") as f:
             f.write(key_data.decode("utf-8"))
             f.write(cert_data.decode("utf-8"))
-
-    print(f"Certificate and key written to {output_path_cert_combined}")
+            print(
+                f"Combined issuing and root certificate bundle and private key written to {output_path_cert_combined}"
+            )
 
 
 if __name__ == "__main__":

--- a/utils/server-cert.py
+++ b/utils/server-cert.py
@@ -24,7 +24,10 @@ def create_session(profile):
     """
 
     try:
-        session = boto3.session.Session(profile_name=profile)
+        if profile is not None:
+            session = boto3.session.Session(profile_name=profile)
+        else:
+            session = boto3.session.Session()
     except Exception as e:
         session = {"error": e}
     if isinstance(session, dict):
@@ -42,7 +45,7 @@ def parse_arguments():
 
     arguments = {}
     parser = argparse.ArgumentParser()
-    parser.add_argument("--profile", default="default", help="AWS profile described in .aws/config file")
+    parser.add_argument("--profile", default=None, help="AWS profile described in .aws/config file")
     parser.add_argument("--verbose", action="store_true", help="Output of all generated payload data")
     arguments = vars(parser.parse_args())
 
@@ -57,8 +60,7 @@ def main():  # pylint:disable=too-many-locals,too-many-statements
     args = parse_arguments()
 
     # create AWS session
-    profile_name = args["profile"]
-    session = create_session(profile_name)
+    session = create_session(args["profile"])
 
     # set variables
     lifetime = 90

--- a/utils/templates/client_certificate_variables.json
+++ b/utils/templates/client_certificate_variables.json
@@ -1,0 +1,13 @@
+{
+  "lifetime": 90,
+  "common_name": "First Test Certificate",
+  "country": "OZ",
+  "locality": "Emerald City",
+  "state": "Gillikin Country",
+  "organization": "TytoCare",
+  "organizational_unit": "Security Operations",
+  "purposes": [
+    "client_auth"
+  ],
+  "key_alias": "serverless-tls-keygen-dev"
+}

--- a/utils/templates/client_certificate_variables.json
+++ b/utils/templates/client_certificate_variables.json
@@ -1,10 +1,10 @@
 {
   "lifetime": 90,
   "common_name": "First Test Certificate",
-  "country": "OZ",
-  "locality": "Emerald City",
-  "state": "Gillikin Country",
-  "organization": "TytoCare",
+  "country": "GB",
+  "locality": "London",
+  "state": "England",
+  "organization": "Serverless Inc",
   "organizational_unit": "Security Operations",
   "purposes": [
     "client_auth"

--- a/utils/variables/client.json
+++ b/utils/variables/client.json
@@ -1,0 +1,13 @@
+{
+  "lifetime": 90,
+  "common_name": "My Test Certificate",
+  "country": "GB",
+  "locality": "London",
+  "state": "England",
+  "organization": "Serverless Inc",
+  "organizational_unit": "Security Operations",
+  "purposes": [
+    "client_auth"
+  ],
+  "key_alias": "serverless-tls-keygen-dev"
+}

--- a/utils/variables/server.json
+++ b/utils/variables/server.json
@@ -1,13 +1,14 @@
 {
   "lifetime": 90,
-  "common_name": "First Test Certificate",
+  "common_name": "test.example.com",
+  "sans": ["test.example.com", "test2.example.com"],
   "country": "GB",
   "locality": "London",
   "state": "England",
   "organization": "Serverless Inc",
   "organizational_unit": "Security Operations",
   "purposes": [
-    "client_auth"
+    "server_auth"
   ],
   "key_alias": "serverless-tls-keygen-dev"
 }


### PR DESCRIPTION
Adapted certificate generation files to use Amazon profiles.
Added the verbose parameter to disable output of full generated payload.
Fixed output descriptions of generated files for better understanding of their contents.

As the script files for client and server certificates generation are roughly the same, a new universal script has been added that can accept the "--server" argument to generate a server certificate, otherwise it will generate the user certificate.
This new script can also take variables for certificate generation from the file, so you can use the '--vardir' and '--varfile' arguments to specify the directory and file containing the variables.
The '--destination' argument can be used to specify the destination directory for generated files.
The '--keyalgo' argument can be used to override the key specs.
The '--keygenalias' argument can be used to override the corresponding variable from the variable file. If not specified, the 'key_alias' argument from the file will be used.

If the arguments are omitted, the script will use the 'utils/variables' directory and the 'client.json' file as the variable file. The default destination directory path is "~/ca/certificates".