### PR TITLE
Fix/prod envs variable not propagated

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -72,7 +72,7 @@
 | <a name="input_logging_account_id"></a> [logging\_account\_id](#input\_logging\_account\_id) | AWS Account ID of central logging account for CloudWatch subscription filters | `string` | `""` | no |
 | <a name="input_max_cert_lifetime"></a> [max\_cert\_lifetime](#input\_max\_cert\_lifetime) | Maximum end entity certificate lifetime in days | `number` | `365` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Standard memory allocation for Lambda functions | `number` | `128` | no |
-| <a name="input_prod_envs"></a> [prod\_envs](#input\_prod\_envs) | List of production environment names, used in outputs.tf | `list` | <pre>[<br/>  "prd",<br/>  "prod"<br/>]</pre> | no |
+| <a name="input_prod_envs"></a> [prod\_envs](#input\_prod\_envs) | List of production environment names, for these names the environment name suffix is not required in resource names | `list` | <pre>[<br/>  "prd",<br/>  "prod"<br/>]</pre> | no |
 | <a name="input_project"></a> [project](#input\_project) | abbreviation for the project, forms first part of resource names | `string` | `"serverless"` | no |
 | <a name="input_public_crl"></a> [public\_crl](#input\_public\_crl) | Whether to make the CRL and CA certificates publicly available | `bool` | `false` | no |
 | <a name="input_root_ca_info"></a> [root\_ca\_info](#input\_root\_ca\_info) | Root CA certificate information | `map` | <pre>{<br/>  "commonName": "Serverless Root CA",<br/>  "country": "GB",<br/>  "emailAddress": null,<br/>  "lifetime": 7300,<br/>  "locality": "London",<br/>  "organization": "Serverless",<br/>  "organizationalUnit": "IT",<br/>  "pathLengthConstraint": null,<br/>  "state": "London"<br/>}</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ module "kms_tls_keygen" {
 
   project     = "${var.project}-tls-keygen"
   env         = var.env
+  prod_envs   = var.prod_envs
   description = "${var.project}-${var.env} asymmetric key generation for TLS certs without CSR"
 }
 
@@ -13,6 +14,7 @@ module "kms_rsa_root_ca" {
 
   project                  = "${var.project}-root-ca"
   env                      = var.env
+  prod_envs                = var.prod_envs
   description              = "${var.project}-${var.env} Root CA key pair"
   customer_master_key_spec = var.root_ca_key_spec
   key_usage                = "SIGN_VERIFY"
@@ -25,6 +27,7 @@ module "kms_rsa_issuing_ca" {
 
   project                  = "${var.project}-issuing-ca"
   env                      = var.env
+  prod_envs                = var.prod_envs
   description              = "${var.project}-${var.env} Issuing CA key pair"
   customer_master_key_spec = var.issuing_ca_key_spec
   key_usage                = "SIGN_VERIFY"
@@ -179,6 +182,7 @@ module "create_rsa_root_ca_lambda" {
 
   project                         = var.project
   env                             = var.env
+  prod_envs                       = var.prod_envs
   function_name                   = "create-root-ca"
   description                     = "create Root Certificate Authority with KMS private key"
   external_s3_bucket              = module.external_s3.s3_bucket_name
@@ -200,6 +204,7 @@ module "create_rsa_issuing_ca_lambda" {
 
   project                         = var.project
   env                             = var.env
+  prod_envs                       = var.prod_envs
   function_name                   = "create-issuing-ca"
   description                     = "create Issuing Certificate Authority with KMS private key"
   external_s3_bucket              = module.external_s3.s3_bucket_name
@@ -221,6 +226,7 @@ module "rsa_root_ca_crl_lambda" {
 
   project                         = var.project
   env                             = var.env
+  prod_envs                       = var.prod_envs
   function_name                   = "root-ca-crl"
   description                     = "publish Root CA certificate revocation list signed by KMS private key"
   external_s3_bucket              = module.external_s3.s3_bucket_name
@@ -244,6 +250,7 @@ module "rsa_issuing_ca_crl_lambda" {
 
   project                         = var.project
   env                             = var.env
+  prod_envs                       = var.prod_envs
   function_name                   = "issuing-ca-crl"
   description                     = "publish Issuing CA certificate revocation list signed by KMS private key"
   external_s3_bucket              = module.external_s3.s3_bucket_name
@@ -267,6 +274,7 @@ module "rsa_tls_cert_lambda" {
 
   project                         = var.project
   env                             = var.env
+  prod_envs                       = var.prod_envs
   function_name                   = "tls-cert"
   description                     = "issue TLS certificates signed by KMS private key"
   external_s3_bucket              = module.external_s3.s3_bucket_name

--- a/modules/terraform-aws-ca-kms/main.tf
+++ b/modules/terraform-aws-ca-kms/main.tf
@@ -11,6 +11,6 @@ resource "aws_kms_key" "encryption" {
 }
 
 resource "aws_kms_alias" "encryption" {
-  name          = contains(["prd", "prod"], var.env) ? "alias/${var.project}" : "alias/${var.project}-${var.env}"
+  name          = contains(var.prod_envs, var.env) ? "alias/${var.project}" : "alias/${var.project}-${var.env}"
   target_key_id = aws_kms_key.encryption.key_id
 }

--- a/modules/terraform-aws-ca-kms/variables.tf
+++ b/modules/terraform-aws-ca-kms/variables.tf
@@ -14,6 +14,11 @@ variable "env" {
   description = "Environment name, e.g. dev"
 }
 
+variable "prod_envs" {
+  description = "List of production environment names. Used to define resource name suffix"
+  default     = ["prd", "prod"]
+}
+
 variable "kms_policy" {
   description = "KMS policy to use"
   default     = "default"

--- a/modules/terraform-aws-ca-lambda/main.tf
+++ b/modules/terraform-aws-ca-lambda/main.tf
@@ -50,6 +50,7 @@ resource "aws_lambda_function" "lambda" {
     variables = {
       DOMAIN              = var.domain
       ENVIRONMENT_NAME    = var.env
+      PROD_ENVIRONMENTS   = jsonencode(var.prod_envs)
       EXTERNAL_S3_BUCKET  = var.external_s3_bucket
       INTERNAL_S3_BUCKET  = var.internal_s3_bucket
       ISSUING_CA_INFO     = jsonencode(var.issuing_ca_info)

--- a/modules/terraform-aws-ca-lambda/utils/certs/ca.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/ca.py
@@ -1,3 +1,5 @@
+from os import environ
+from json import loads
 from datetime import datetime, timezone, timedelta
 from cryptography import x509
 from cryptography.x509 import (
@@ -17,7 +19,12 @@ from .types import Subject
 
 
 def ca_name(project, env_name, hierarchy):
-    if env_name in ["prd", "prod"]:
+    prod_envs_str = environ.get("PROD_ENVIRONMENTS")
+    if prod_envs_str:
+        prod_envs = loads(prod_envs_str)
+    else:
+        prod_envs = ["prd", "prod"]
+    if env_name in prod_envs:
         return f"{project}-{hierarchy.lower()}-ca"
 
     return f"{project}-{hierarchy.lower()}-ca-{env_name}"
@@ -242,7 +249,12 @@ def ca_kms_sign_tls_certificate_request(
 
 def ca_bundle_name(project, env_name):
     """Returns CA bundle name for uploading to S3"""
-    if env_name in ["prd", "prod"]:
+    prod_envs_str = environ.get("PROD_ENVIRONMENTS")
+    if prod_envs_str:
+        prod_envs = loads(prod_envs_str)
+    else:
+        prod_envs = ["prd", "prod"]
+    if env_name in prod_envs:
         return f"{project}-ca-bundle"
     return f"{project}-ca-bundle-{env_name}"
 

--- a/modules/terraform-aws-ca-lambda/variables.tf
+++ b/modules/terraform-aws-ca-lambda/variables.tf
@@ -20,6 +20,11 @@ variable "env" {
   description = "Environment name, e.g. dev"
 }
 
+variable "prod_envs" {
+  description = "List of production environment names. Used to define resource name suffix"
+  default     = ["prd", "prod"]
+}
+
 variable "external_s3_bucket" {
   description = "External S3 Bucket Name"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -126,7 +126,7 @@ variable "memory_size" {
 }
 
 variable "prod_envs" {
-  description = "List of production environment names, used in outputs.tf"
+  description = "List of production environment names, for these names the environment name suffix is not required in resource names"
   default     = ["prd", "prod"]
 }
 


### PR DESCRIPTION
The prod_envs variable does not affect anything except output, since it is hardcoded everywhere.
This change allows you to define an empty list, so all resources will be created with the suffix. Or you can leave it as default, so the behavior will not change.