### PR TITLE
Internal S3 bucket encryption key ARN fixed

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -53,11 +53,13 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_logs"></a> [access\_logs](#input\_access\_logs) | Enable access logs for S3 buckets, requires log\_bucket variable to be set | `bool` | `false` | no |
 | <a name="input_aws_principals"></a> [aws\_principals](#input\_aws\_principals) | List of ARNs for AWS principals allowed to assume DynamoDB reader role or execute the tls\_cert lambda | `list` | `[]` | no |
+| <a name="input_bucket_key_enabled"></a> [bucket\_key\_enabled](#input\_bucket\_key\_enabled) | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS | `bool` | `false` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | First part of s3 bucket name to ensure uniqueness, if left blank a random suffix will be used instead | `string` | `""` | no |
 | <a name="input_cert_info_files"></a> [cert\_info\_files](#input\_cert\_info\_files) | List of file names to be uploaded to internal S3 bucket for processing | `list` | `[]` | no |
 | <a name="input_csr_files"></a> [csr\_files](#input\_csr\_files) | List of CSR file names to be uploaded to internal S3 bucket for processing | `list` | `[]` | no |
 | <a name="input_custom_sns_topic_display_name"></a> [custom\_sns\_topic\_display\_name](#input\_custom\_sns\_topic\_display\_name) | Customised SNS topic display name, leave empty to use standard naming convention | `string` | `""` | no |
 | <a name="input_custom_sns_topic_name"></a> [custom\_sns\_topic\_name](#input\_custom\_sns\_topic\_name) | Customised SNS topic name, leave empty to use standard naming convention | `string` | `""` | no |
+| <a name="input_default_aws_kms_key_for_s3"></a> [default\_aws\_kms\_key\_for\_s3](#input\_default\_aws\_kms\_key\_for\_s3) | Use default AWS KMS key instead of customer managed key for S3 bucket encryption. Applicable only if "sse\_algorithm" is "aws:kms" | `bool` | `false` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment name, e.g. dev | `string` | `"dev"` | no |
 | <a name="input_filter_pattern"></a> [filter\_pattern](#input\_filter\_pattern) | Filter pattern for CloudWatch logs subscription filter | `string` | `""` | no |
 | <a name="input_hosted_zone_domain"></a> [hosted\_zone\_domain](#input\_hosted\_zone\_domain) | Hosted zone domain, e.g. dev.ca.example.com | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -64,12 +64,14 @@ module "internal_s3" {
   # S3 bucket for internal processing of JSON files for certificates to be issued and revoked
   source = "./modules/terraform-aws-ca-s3"
 
-  purpose       = "${var.project}-ca-internal-${var.env}"
-  global_bucket = true
-  bucket_prefix = var.bucket_prefix
-  access_logs   = var.access_logs
-  log_bucket    = var.log_bucket
-  kms_key_alias = var.kms_key_alias == "" ? module.kms_tls_keygen.kms_alias_arn : var.kms_key_alias
+  purpose             = "${var.project}-ca-internal-${var.env}"
+  global_bucket       = true
+  bucket_prefix       = var.bucket_prefix
+  access_logs         = var.access_logs
+  log_bucket          = var.log_bucket
+  kms_key_alias       = var.kms_key_alias == "" ? module.kms_tls_keygen.kms_alias_name : var.kms_key_alias
+  default_aws_kms_key = var.default_aws_kms_key_for_s3
+  bucket_key_enabled  = var.bucket_key_enabled
 }
 
 resource "aws_s3_object" "cert_info" {

--- a/modules/terraform-aws-ca-kms/outputs.tf
+++ b/modules/terraform-aws-ca-kms/outputs.tf
@@ -2,6 +2,10 @@ output "kms_arn" {
   value = aws_kms_key.encryption.arn
 }
 
+output "kms_alias_name" {
+  value = aws_kms_alias.encryption.name
+}
+
 output "kms_alias_arn" {
   value = aws_kms_alias.encryption.arn
 }

--- a/modules/terraform-aws-ca-s3/locals.tf
+++ b/modules/terraform-aws-ca-s3/locals.tf
@@ -16,7 +16,7 @@ locals {
   standard_bucket_name = local.bucket_prefix == "" ? "${var.purpose}-${var.environment}-${random_string.suffix[0].result}" : "${local.bucket_prefix}-${var.purpose}-${var.environment}"
   global_bucket_name   = local.bucket_prefix == "" ? "${var.purpose}-${random_string.suffix[0].result}" : "${local.bucket_prefix}-${var.purpose}"
   bucket_name          = var.global_bucket ? local.global_bucket_name : local.standard_bucket_name
-  kms_key_alias_arn    = var.default_aws_kms_key ? null : var.kms_key_alias
+  kms_key_alias_arn    = var.default_aws_kms_key ? null : "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/${var.kms_key_alias}"
   region               = data.aws_region.current.name
   tags = merge(var.tags, {
     Terraform = "true"

--- a/modules/terraform-aws-ca-s3/locals.tf
+++ b/modules/terraform-aws-ca-s3/locals.tf
@@ -16,7 +16,7 @@ locals {
   standard_bucket_name = local.bucket_prefix == "" ? "${var.purpose}-${var.environment}-${random_string.suffix[0].result}" : "${local.bucket_prefix}-${var.purpose}-${var.environment}"
   global_bucket_name   = local.bucket_prefix == "" ? "${var.purpose}-${random_string.suffix[0].result}" : "${local.bucket_prefix}-${var.purpose}"
   bucket_name          = var.global_bucket ? local.global_bucket_name : local.standard_bucket_name
-  kms_key_alias_arn    = var.default_aws_kms_key ? null : "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/${var.kms_key_alias}"
+  kms_key_alias_arn    = "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.kms_key_alias}"
   region               = data.aws_region.current.name
   tags = merge(var.tags, {
     Terraform = "true"

--- a/modules/terraform-aws-ca-s3/locals.tf
+++ b/modules/terraform-aws-ca-s3/locals.tf
@@ -16,7 +16,7 @@ locals {
   standard_bucket_name = local.bucket_prefix == "" ? "${var.purpose}-${var.environment}-${random_string.suffix[0].result}" : "${local.bucket_prefix}-${var.purpose}-${var.environment}"
   global_bucket_name   = local.bucket_prefix == "" ? "${var.purpose}-${random_string.suffix[0].result}" : "${local.bucket_prefix}-${var.purpose}"
   bucket_name          = var.global_bucket ? local.global_bucket_name : local.standard_bucket_name
-  kms_key_alias_arn    = var.default_aws_kms_key ? null : "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/${var.kms_key_alias}"
+  kms_key_alias_arn    = var.default_aws_kms_key ? null : var.kms_key_alias
   region               = data.aws_region.current.name
   tags = merge(var.tags, {
     Terraform = "true"

--- a/modules/terraform-aws-ca-s3/main.tf
+++ b/modules/terraform-aws-ca-s3/main.tf
@@ -30,7 +30,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "kms" {
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = var.kms_encryption_key_arn != "" ? var.kms_encryption_key_arn : local.kms_key_alias_arn
+      kms_master_key_id = var.default_aws_kms_key ? null : (var.kms_encryption_key_arn != "" ? var.kms_encryption_key_arn : local.kms_key_alias_arn)
       sse_algorithm     = var.sse_algorithm
     }
     bucket_key_enabled = var.bucket_key_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,16 @@ variable "kms_arn_resource" {
   default     = ""
 }
 
+variable "default_aws_kms_key_for_s3" {
+  description = "Use default AWS KMS key instead of customer managed key for S3 bucket encryption. Applicable only if \"sse_algorithm\" is \"aws:kms\""
+  default     = false
+}
+
+variable "bucket_key_enabled" {
+  description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS"
+  default     = false
+}
+
 variable "log_bucket" {
   description = "Name of log bucket, if access_logs variable set to true"
   default     = ""
@@ -244,3 +254,4 @@ variable "timeout" {
   description = "Amount of time Lambda Function has to run in seconds"
   default     = 180
 }
+


### PR DESCRIPTION
If no external KMS key is used, the module uses the key generated by the **kms_tls_keygen** module. The module provides output **kms_alias_arn**, which is a well-formed ARN.
The **kms_key_alias_arn** local variable for the **terraform-aws-ca-s3** module does string formatting to create an alias, which is not needed since the variable already contains the ARN, no need to form it.
As a result, the bucket is created with an incorrect value for the **Encryption Key ARN** parameter in the Default encryption settings part.