### PR TITLE
Add the ability to disable X-Ray traces

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -91,6 +91,7 @@
 | <a name="input_sns_sqs_subscriptions"></a> [sns\_sqs\_subscriptions](#input\_sns\_sqs\_subscriptions) | A map of SQS names to arns to subscribe to thSNSis topic | `map(string)` | `{}` | no |
 | <a name="input_subscription_filter_destination"></a> [subscription\_filter\_destination](#input\_subscription\_filter\_destination) | CloudWatch log subscription filter destination, last section of ARN | `string` | `""` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Amount of time Lambda Function has to run in seconds | `number` | `180` | no |
+| <a name="input_xray_enabled"></a> [xray\_enabled](#input\_xray\_enabled) | Whether to enable active tracing with AWS X-Ray | `bool` | `true` | no |
 
 ## Outputs
 

--- a/examples/rsa-public-crl/ca.tf
+++ b/examples/rsa-public-crl/ca.tf
@@ -14,6 +14,7 @@ module "certificate_authority" {
   public_crl          = true
   cert_info_files     = ["tls", "revoked", "revoked-root-ca"]
   kms_key_alias       = "custom-kms-encryption-key"
+  xray_enabled        = false 
 
   custom_sns_topic_display_name = "My Company CA Notifications Production"
 

--- a/examples/rsa-public-crl/ca.tf
+++ b/examples/rsa-public-crl/ca.tf
@@ -14,7 +14,7 @@ module "certificate_authority" {
   public_crl          = true
   cert_info_files     = ["tls", "revoked", "revoked-root-ca"]
   kms_key_alias       = "custom-kms-encryption-key"
-  xray_enabled        = false 
+  xray_enabled        = false
 
   custom_sns_topic_display_name = "My Company CA Notifications Production"
 

--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,7 @@ module "create_root_ca_iam" {
   policy                 = "root_ca"
   external_s3_bucket_arn = module.external_s3.s3_bucket_arn
   internal_s3_bucket_arn = module.internal_s3.s3_bucket_arn
+  xray_enabled           = var.xray_enabled
 }
 
 module "create_issuing_ca_iam" {
@@ -129,6 +130,7 @@ module "create_issuing_ca_iam" {
   policy                 = "issuing_ca"
   external_s3_bucket_arn = module.external_s3.s3_bucket_arn
   internal_s3_bucket_arn = module.internal_s3.s3_bucket_arn
+  xray_enabled           = var.xray_enabled
 }
 
 module "root_crl_iam" {
@@ -144,6 +146,7 @@ module "root_crl_iam" {
   policy                 = "root_crl"
   external_s3_bucket_arn = module.external_s3.s3_bucket_arn
   internal_s3_bucket_arn = module.internal_s3.s3_bucket_arn
+  xray_enabled           = var.xray_enabled
 }
 
 module "issuing_crl_iam" {
@@ -159,6 +162,7 @@ module "issuing_crl_iam" {
   policy                 = "issuing_crl"
   external_s3_bucket_arn = module.external_s3.s3_bucket_arn
   internal_s3_bucket_arn = module.internal_s3.s3_bucket_arn
+  xray_enabled           = var.xray_enabled
 }
 
 module "tls_keygen_iam" {
@@ -176,6 +180,7 @@ module "tls_keygen_iam" {
   external_s3_bucket_arn = module.external_s3.s3_bucket_arn
   internal_s3_bucket_arn = module.internal_s3.s3_bucket_arn
   sns_topic_arn          = module.sns_ca_notifications.sns_topic_arn
+  xray_enabled           = var.xray_enabled
 }
 
 module "create_rsa_root_ca_lambda" {
@@ -198,6 +203,7 @@ module "create_rsa_root_ca_lambda" {
   runtime                         = var.runtime
   public_crl                      = var.public_crl
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
+  xray_enabled                    = var.xray_enabled
 }
 
 module "create_rsa_issuing_ca_lambda" {
@@ -220,6 +226,7 @@ module "create_rsa_issuing_ca_lambda" {
   runtime                         = var.runtime
   public_crl                      = var.public_crl
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
+  xray_enabled                    = var.xray_enabled
 }
 
 module "rsa_root_ca_crl_lambda" {
@@ -244,6 +251,7 @@ module "rsa_root_ca_crl_lambda" {
   runtime                         = var.runtime
   public_crl                      = var.public_crl
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
+  xray_enabled                    = var.xray_enabled
 }
 
 module "rsa_issuing_ca_crl_lambda" {
@@ -268,6 +276,7 @@ module "rsa_issuing_ca_crl_lambda" {
   runtime                         = var.runtime
   public_crl                      = var.public_crl
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
+  xray_enabled                    = var.xray_enabled
 }
 
 module "rsa_tls_cert_lambda" {
@@ -292,6 +301,7 @@ module "rsa_tls_cert_lambda" {
   max_cert_lifetime               = var.max_cert_lifetime
   allowed_invocation_principals   = var.aws_principals
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
+  xray_enabled                    = var.xray_enabled
 }
 
 module "cloudfront_certificate" {

--- a/modules/terraform-aws-ca-iam/main.tf
+++ b/modules/terraform-aws-ca-iam/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "lambda" {
-  name               = "${var.project}-${var.function_name}-${var.env}"
+  name = "${var.project}-${var.function_name}-${var.env}"
   assume_role_policy = templatefile("${path.module}/templates/${var.assume_role_policy}_role.json.tpl", {
     aws_principals = var.aws_principals
     project        = var.project
@@ -7,8 +7,8 @@ resource "aws_iam_role" "lambda" {
 }
 
 resource "aws_iam_role_policy" "lambda" {
-  name   = "${var.project}-${var.function_name}-${var.env}"
-  role   = aws_iam_role.lambda.id
+  name = "${var.project}-${var.function_name}-${var.env}"
+  role = aws_iam_role.lambda.id
   policy = templatefile("${path.module}/templates/${var.policy}_policy.json.tpl", {
     kms_arn_issuing_ca     = var.kms_arn_issuing_ca,
     kms_arn_root_ca        = var.kms_arn_root_ca,

--- a/modules/terraform-aws-ca-iam/main.tf
+++ b/modules/terraform-aws-ca-iam/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "lambda" {
-  name = "${var.project}-${var.function_name}-${var.env}"
+  name               = "${var.project}-${var.function_name}-${var.env}"
   assume_role_policy = templatefile("${path.module}/templates/${var.assume_role_policy}_role.json.tpl", {
     aws_principals = var.aws_principals
     project        = var.project
@@ -7,8 +7,8 @@ resource "aws_iam_role" "lambda" {
 }
 
 resource "aws_iam_role_policy" "lambda" {
-  name = "${var.project}-${var.function_name}-${var.env}"
-  role = aws_iam_role.lambda.id
+  name   = "${var.project}-${var.function_name}-${var.env}"
+  role   = aws_iam_role.lambda.id
   policy = templatefile("${path.module}/templates/${var.policy}_policy.json.tpl", {
     kms_arn_issuing_ca     = var.kms_arn_issuing_ca,
     kms_arn_root_ca        = var.kms_arn_root_ca,
@@ -19,4 +19,10 @@ resource "aws_iam_role_policy" "lambda" {
     internal_s3_bucket_arn = var.internal_s3_bucket_arn
     sns_topic_arn          = var.sns_topic_arn
   })
+}
+
+resource "aws_iam_role_policy_attachment" "xray" {
+  count      = var.xray_enabled ? 1 : 0
+  role       = aws_iam_role.lambda.name
+  policy_arn = var.xray_daemon_policy_arn
 }

--- a/modules/terraform-aws-ca-iam/variables.tf
+++ b/modules/terraform-aws-ca-iam/variables.tf
@@ -60,3 +60,14 @@ variable "sns_topic_arn" {
   description = "SNS Topic ARN"
   default     = ""
 }
+
+variable "xray_enabled" {
+  description = "Whether to add permissions to allow to send trace data to X-Ray"
+  default     = false
+}
+
+variable "xray_daemon_policy_arn" {
+  description = "AWSXRayDaemonWriteAccess managed policy ARN"
+  default     = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+

--- a/modules/terraform-aws-ca-lambda/main.tf
+++ b/modules/terraform-aws-ca-lambda/main.tf
@@ -67,7 +67,7 @@ resource "aws_lambda_function" "lambda" {
   }
 
   tracing_config {
-    mode = "Active"
+    mode = var.xray_enabled ? "Active" : "PassThrough"
   }
 
   depends_on = [data.archive_file.lambda_zip]

--- a/modules/terraform-aws-ca-lambda/variables.tf
+++ b/modules/terraform-aws-ca-lambda/variables.tf
@@ -127,3 +127,8 @@ variable "timeout" {
   description = "Amount of time Lambda Function has to run in seconds"
   default     = 180
 }
+
+variable "xray_enabled" {
+  description = "Whether to enable active tracing with AWS X-Ray"
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -255,3 +255,8 @@ variable "timeout" {
   default     = 180
 }
 
+variable "xray_enabled" {
+  description = "Whether to enable active tracing with AWS X-Ray"
+  default     = true
+}
+


### PR DESCRIPTION
AWS X-Ray active tracing is enabled by default, but the module does not add appropriate permissions to put data.
Added attachment of AWSXRayDaemonWriteAccess managed policy in case X-Ray is enabled.
Also added variable allowing to disable X-Ray tracing if not needed.