### PR TITLE
Update outputs.tf with bundle key

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "cloudfront_domain_name" {
   description = "Domain name of CloudFront distribution used for public CRL"
 }
 
+output "ca_bundle_s3_key" {
+  value       = contains(var.prod_envs, var.env) ? "${var.project}-ca-bundle.pem" : "${var.project}-ca-bundle-${var.env}.pem"
+  description = "S3 key (name) of CA bundle"
+}
+
 output "ca_bundle_s3_location" {
   value       = contains(var.prod_envs, var.env) ? "${module.external_s3.s3_bucket_domain_name}/${var.project}-ca-bundle.pem" : "${module.external_s3.s3_bucket_domain_name}/${var.project}-ca-bundle-${var.env}.pem"
   description = "S3 location of CA bundle for use as a TrustStore"


### PR DESCRIPTION
outputs.tf: Add bundle key

Add key for CA bundle in external S3 bucket.

In the [aws_lb_trust_store](https://registry.terraform.io/providers/-/aws/latest/docs/resources/lb_trust_store#ca_certificates_bundle_s3_key-2) AWS provider resource, they need the `ca_certificates_bundle_s3_key`, which is just the name for the bundle file in the external S3 object.

I can now configure the resource as:
```
resource "aws_lb_trust_store" "example" {
  name = "example-trust-store"

  ca_certificates_bundle_s3_bucket = module.serverless_ca["${var.env}"].external_s3_bucket_name
  ca_certificates_bundle_s3_key    = module.serverless_ca["${var.env}"].ca_bundle_s3_key
}
```

I was tempted to remove `ca_bundle_s3_location` but I'm not sure if that's needed somewhere else or by a legacy version of this provider.