### PR TITLE
feat(WAF): Add WAF integration to the public CRL CloudFront distribution

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -328,6 +328,7 @@ module "ca_cloudfront" {
   certificate_arn             = module.cloudfront_certificate[0].certificate_arn
   environment                 = var.env
   zone_id                     = var.hosted_zone_id
+  web_acl_id                  = var.cloudfront_web_acl_id
 }
 
 module "step-function-role" {

--- a/modules/terraform-aws-ca-cloudfront/main.tf
+++ b/modules/terraform-aws-ca-cloudfront/main.tf
@@ -16,6 +16,7 @@ resource "aws_cloudfront_distribution" "website" {
   enabled             = true
   is_ipv6_enabled     = true
   comment             = "Static web site for ${local.domain_name}"
+  web_acl_id          = var.web_acl_id
   default_root_object = "index.html"
 
   aliases = [var.domain_prefix == "" ? var.base_domain : "${var.domain_prefix}.${var.base_domain}"]

--- a/modules/terraform-aws-ca-cloudfront/variables.tf
+++ b/modules/terraform-aws-ca-cloudfront/variables.tf
@@ -35,3 +35,9 @@ variable "error_page" {
   description = "Path to custom 404 error page"
   default     = "/page-not-found.html"
 }
+
+variable "web_acl_id" {
+  description = "WAF attachment for the public CRL Cloudfront distribution, expects the WAF ARN"
+  default     = null
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,12 @@ variable "csr_files" {
   default     = []
 }
 
+variable "cloudfront_web_acl_id" {
+  description = "WAF attachment for the public CRL Cloudfront distribution, expects the WAF ARN"
+  default     = null
+  type        = string
+}
+
 variable "custom_sns_topic_display_name" {
   description = "Customised SNS topic display name, leave empty to use standard naming convention"
   default     = ""
@@ -259,4 +265,3 @@ variable "xray_enabled" {
   description = "Whether to enable active tracing with AWS X-Ray"
   default     = true
 }
-


### PR DESCRIPTION
I added the possibility of attaching the WAF integration to the public CRL CloudFront distribution.
The `cloudfront_web_acl_id` variable expects the WAF ARN.