### PR TITLE
Ensure S3 KMS included in Lambda role policy

### DIFF
--- a/modules/terraform-aws-ca-iam/locals.tf
+++ b/modules/terraform-aws-ca-iam/locals.tf
@@ -1,3 +1,7 @@
 locals {
   account_id = data.aws_caller_identity.current.account_id
+
+  kms_arns_symmetric = distinct([
+    for arn in [var.kms_arn_tls_keygen, var.kms_arn_resource] : arn if arn != ""
+  ])
 }

--- a/modules/terraform-aws-ca-iam/main.tf
+++ b/modules/terraform-aws-ca-iam/main.tf
@@ -14,6 +14,7 @@ resource "aws_iam_role_policy" "lambda" {
     kms_arn_root_ca        = var.kms_arn_root_ca,
     kms_arn_tls_keygen     = var.kms_arn_tls_keygen,
     kms_arn_resource       = var.kms_arn_resource,
+    kms_arns_symmetric     = local.kms_arns_symmetric,
     ddb_table_arn          = var.ddb_table_arn,
     external_s3_bucket_arn = var.external_s3_bucket_arn,
     internal_s3_bucket_arn = var.internal_s3_bucket_arn

--- a/modules/terraform-aws-ca-iam/templates/issuing_ca_policy.json.tpl
+++ b/modules/terraform-aws-ca-iam/templates/issuing_ca_policy.json.tpl
@@ -49,7 +49,7 @@
         "kms:Encrypt",
         "kms:GenerateDataKey"
       ],
-      "Resource": "${kms_arn_resource}"
+      "Resource": ${jsonencode(kms_arns_symmetric)}
     },
     {
       "Sid": "DynamoDB",

--- a/modules/terraform-aws-ca-iam/templates/issuing_crl_policy.json.tpl
+++ b/modules/terraform-aws-ca-iam/templates/issuing_crl_policy.json.tpl
@@ -46,7 +46,7 @@
         "kms:Encrypt",
         "kms:GenerateDataKey"
       ],
-      "Resource": "${kms_arn_resource}"
+      "Resource": ${jsonencode(kms_arns_symmetric)}
     },
     {
       "Sid": "DynamoDB",

--- a/modules/terraform-aws-ca-iam/templates/root_ca_policy.json.tpl
+++ b/modules/terraform-aws-ca-iam/templates/root_ca_policy.json.tpl
@@ -46,7 +46,7 @@
         "kms:Encrypt",
         "kms:GenerateDataKey"
       ],
-      "Resource": "${kms_arn_resource}"
+      "Resource": ${jsonencode(kms_arns_symmetric)}
     },
     {
       "Sid": "DynamoDB",

--- a/modules/terraform-aws-ca-iam/templates/root_crl_policy.json.tpl
+++ b/modules/terraform-aws-ca-iam/templates/root_crl_policy.json.tpl
@@ -46,7 +46,7 @@
         "kms:Encrypt",
         "kms:GenerateDataKey"
       ],
-      "Resource": "${kms_arn_resource}"
+      "Resource": ${jsonencode(kms_arns_symmetric)}
     },
     {
       "Sid": "DynamoDB",

--- a/modules/terraform-aws-ca-iam/templates/state_policy.json.tpl
+++ b/modules/terraform-aws-ca-iam/templates/state_policy.json.tpl
@@ -84,9 +84,7 @@
         "kms:Encrypt",
         "kms:GenerateDataKey"
       ],
-      "Resource": [
-        ${jsonencode(kms_arns_symmetric)}
-      ]
+      "Resource": ${jsonencode(kms_arns_symmetric)}
     }
   ]
 }

--- a/modules/terraform-aws-ca-iam/templates/state_policy.json.tpl
+++ b/modules/terraform-aws-ca-iam/templates/state_policy.json.tpl
@@ -85,7 +85,7 @@
         "kms:GenerateDataKey"
       ],
       "Resource": [
-        "${kms_arn_resource}"
+        ${jsonencode(kms_arns_symmetric)}
       ]
     }
   ]


### PR DESCRIPTION
If the option of a separate resource KMS encryption key is chosen, the internal S3 bucket nevertheless defaults to using the KMS TLS keygen key, causing issues when the CRL or other Lambdas need to access objects in the internal S3 bucket