### PR TITLE
Add Certificate Profile System with PKINIT Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * 100% serverless
 * CA private keys stored in [FIPS 140-2 level 3 certified hardware](https://aws.amazon.com/about-aws/whats-new/2023/05/aws-kms-hsm-fips-security-level-3)
 * Wide range of [configuration options](https://serverlessca.com/options/)
+* Flexible certificate profiles for different use cases (PKINIT, TLS, custom)
 * Published as a public [Terraform registry module](https://registry.terraform.io/modules/serverless-ca/ca/aws/latest)
 
 <a href="#"><img src="https://raw.githubusercontent.com/serverless-ca/terraform-aws-ca/main/docs/assets/images/ca-architecture-options.png" /></a>

--- a/docs/certificate-profiles.md
+++ b/docs/certificate-profiles.md
@@ -1,0 +1,279 @@
+# Certificate Profiles
+
+The serverless CA supports a flexible certificate profile system that allows issuing certificates with specific extensions and constraints for different use cases, such as PKINIT, TLS, and custom applications.
+
+## Overview
+
+Certificate profiles define the structure and extensions that will be included in issued certificates. This allows you to:
+
+- Issue certificates with specific key usage and extended key usage
+- Apply custom certificate policies and OIDs
+- Configure CRL distribution points and authority information access
+- Set appropriate certificate lifetimes for different use cases
+- Add custom extensions for specialized applications
+
+## Built-in Profiles
+
+The serverless CA includes several built-in profiles:
+
+### TLS Client Profile (`tls_client`)
+- **Purpose**: Standard TLS client certificates
+- **Key Usage**: Digital signature, key encipherment
+- **Extended Key Usage**: Client authentication
+- **Certificate Policy**: `2.23.140.1.2.1` (DV Certificate Policy)
+- **Lifetime**: 365 days
+
+### TLS Server Profile (`tls_server`)
+- **Purpose**: Standard TLS server certificates
+- **Key Usage**: Digital signature, key encipherment
+- **Extended Key Usage**: Server authentication
+- **Certificate Policy**: `2.23.140.1.2.1` (DV Certificate Policy)
+- **Lifetime**: 365 days
+- **Features**: Supports wildcard SANs
+
+### PKINIT KDC Profile (`pkinit_kdc`)
+- **Purpose**: PKINIT KDC certificates for Kerberos authentication
+- **Key Usage**: Digital signature only
+- **Extended Key Usage**: Client and server authentication
+- **Certificate Policy**: `1.3.6.1.5.2.3.5` (PKINIT KDC OID)
+- **Lifetime**: 3650 days (10 years)
+- **Features**: Includes Kerberos principal in SAN
+
+### PKINIT Client Profile (`pkinit_client`)
+- **Purpose**: PKINIT client certificates for Kerberos authentication
+- **Key Usage**: Digital signature only
+- **Extended Key Usage**: Client authentication
+- **Certificate Policy**: `1.3.6.1.5.2.3.5` (PKINIT OID)
+- **Lifetime**: 365 days
+- **Features**: Includes Kerberos principal in SAN
+
+### CA Profile (`ca`)
+- **Purpose**: Certificate Authority certificates
+- **Key Usage**: Digital signature, key cert sign, CRL sign
+- **Basic Constraints**: CA=true
+- **Lifetime**: 7300 days (20 years)
+
+## Using Profiles
+
+### In Certificate Requests
+
+When requesting a certificate, specify the profile using the `profile` field:
+
+```json
+{
+  "common_name": "user@EXAMPLE.COM",
+  "organization": "Example Corp",
+  "lifetime": 365,
+  "profile": "pkinit_client",
+  "force_issue": true
+}
+```
+
+### In Lambda Invocations
+
+When invoking the TLS certificate Lambda directly:
+
+```python
+request_payload = {
+    "common_name": "krbtgt/EXAMPLE.COM@EXAMPLE.COM",
+    "lifetime": 3650,
+    "profile": "pkinit_kdc",
+    "force_issue": True,
+    "cert_bundle": True
+}
+```
+
+## Custom Profiles
+
+You can define custom profiles in your Terraform configuration:
+
+```hcl
+module "certificate_authority" {
+  source = "serverless-ca/ca/aws"
+  
+  certificate_profiles = {
+    "custom_server" = {
+      description = "Custom server certificate with specific requirements"
+      key_usage = {
+        digital_signature = true
+        key_encipherment  = true
+        data_encipherment = false
+        key_agreement     = false
+        key_cert_sign     = false
+        crl_sign          = false
+        content_commitment = false
+        encipher_only     = false
+        decipher_only     = false
+      }
+      extended_key_usage = ["server_auth", "client_auth"]
+      certificate_policies = ["2.23.140.1.2.1"]
+      lifetime_days = 365
+      max_lifetime_days = 365
+      allow_wildcard_sans = true
+    }
+    
+    "code_signing" = {
+      description = "Code signing certificate"
+      key_usage = {
+        digital_signature = true
+        content_commitment = true
+        key_encipherment  = false
+        data_encipherment = false
+        key_agreement     = false
+        key_cert_sign     = false
+        crl_sign          = false
+        encipher_only     = false
+        decipher_only     = false
+      }
+      extended_key_usage = ["code_signing"]
+      certificate_policies = ["1.3.6.1.5.5.7.2.3"]  # Code Signing OID
+      lifetime_days = 1095  # 3 years
+      max_lifetime_days = 1095
+    }
+  }
+}
+```
+
+## Profile Configuration Options
+
+### Key Usage
+Controls the basic key usage extensions:
+```hcl
+key_usage = {
+  digital_signature = true    # Digital signature
+  key_encipherment  = true    # Key encipherment
+  data_encipherment = false   # Data encipherment
+  key_agreement     = false   # Key agreement
+  key_cert_sign     = false   # Certificate signing
+  crl_sign          = false   # CRL signing
+  content_commitment = false  # Content commitment
+  encipher_only     = false   # Encipher only
+  decipher_only     = false   # Decipher only
+}
+```
+
+### Extended Key Usage
+List of extended key usage OIDs:
+```hcl
+extended_key_usage = [
+  "client_auth",      # Client authentication
+  "server_auth",      # Server authentication
+  "code_signing",     # Code signing
+  "email_protection", # Email protection
+  "time_stamping",    # Time stamping
+  "ocsp_signing"      # OCSP signing
+]
+```
+
+### Basic Constraints
+For CA certificates:
+```hcl
+basic_constraints = {
+  ca = true           # Is a CA certificate
+  path_length = null  # Path length constraint (null = unlimited)
+}
+```
+
+### Certificate Policies
+List of certificate policy OIDs:
+```hcl
+certificate_policies = [
+  "2.23.140.1.2.1",  # DV Certificate Policy
+  "1.3.6.1.5.2.3.5"  # PKINIT OID
+]
+```
+
+### CRL Distribution Points
+URLs for CRL distribution:
+```hcl
+crl_distribution_points = [
+  "http://{domain}/issuing-ca.crl"
+]
+```
+
+### Authority Information Access
+URLs for CA certificate and OCSP:
+```hcl
+authority_info_access = [
+  {
+    access_method = "ca_issuers"
+    url = "http://{domain}/issuing-ca.crt"
+  },
+  {
+    access_method = "ocsp"
+    url = "http://{domain}/ocsp"
+  }
+]
+```
+
+### Subject Alternative Names
+Default SANs to include:
+```hcl
+subject_alt_names = [
+  "DNS:example.com",
+  "DNS:*.example.com",
+  "IP:192.168.1.1"
+]
+```
+
+### Lifetime Configuration
+```hcl
+lifetime_days = 365      # Default lifetime
+max_lifetime_days = 365  # Maximum allowed lifetime
+```
+
+### Validation Options
+```hcl
+require_common_name = true   # Require common name
+allow_wildcard_sans = false  # Allow wildcard SANs
+```
+
+## PKINIT Integration
+
+The serverless CA provides built-in support for PKINIT certificates following the [FreeIPA PKINIT specification](https://www.freeipa.org/page/V4/Kerberos_PKINIT):
+
+### KDC Certificates
+- Common name format: `krbtgt/REALM@REALM`
+- Includes Kerberos principal in Subject Alternative Name
+- Uses PKINIT KDC OID (`1.3.6.1.5.2.3.5`)
+- Long lifetime (10 years) for stability
+
+### Client Certificates
+- Common name format: `user@REALM` or `service@REALM`
+- Includes Kerberos principal in Subject Alternative Name
+- Uses PKINIT OID (`1.3.6.1.5.2.3.5`)
+- Standard lifetime (1 year)
+
+### Example Usage
+```bash
+# Generate PKINIT KDC certificate
+python utils/pkinit-cert.py --type kdc --principal "krbtgt/EXAMPLE.COM@EXAMPLE.COM"
+
+# Generate PKINIT client certificate
+python utils/pkinit-cert.py --type client --principal "user@EXAMPLE.COM"
+```
+
+## Best Practices
+
+1. **Use Appropriate Profiles**: Choose profiles that match your use case
+2. **Set Correct Lifetimes**: KDC certificates can have longer lifetimes than client certificates
+3. **Include Required Extensions**: Ensure all necessary extensions are included for your application
+4. **Validate Certificate Policies**: Use the correct OIDs for your certificate type
+5. **Test Integration**: Verify that issued certificates work with your target applications
+
+## Troubleshooting
+
+### Profile Not Found
+- Ensure the profile name is spelled correctly
+- Check that the profile is defined in your Terraform configuration
+- Verify that the profile is loaded in the Lambda environment
+
+### Invalid Extensions
+- Review the profile configuration for syntax errors
+- Ensure all required fields are provided
+- Check that OIDs are in the correct format
+
+### Certificate Validation Issues
+- Verify that the certificate includes all required extensions
+- Check that the certificate policy OIDs are correct
+- Ensure the key usage matches your application requirements

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ description: Serverless CA in AWS with FIPS 140-2 level 3 CA key storage and cos
 * 100% serverless
 * CA private keys stored in [FIPS 140-2 level 3 certified hardware](https://aws.amazon.com/about-aws/whats-new/2023/05/aws-kms-hsm-fips-security-level-3)
 * Wide range of [configuration options](options.md)
+* Flexible [certificate profiles](certificate-profiles.md) for different use cases (PKINIT, TLS, custom)
 * Published as a public [Terraform registry module](https://registry.terraform.io/modules/serverless-ca/ca/aws/latest)
 
 ![Alt text](assets/images/ca-architecture-options.png?raw=true "CA architecture")

--- a/examples/pkinit/README.md
+++ b/examples/pkinit/README.md
@@ -1,0 +1,122 @@
+# PKINIT Certificate Example
+
+This example demonstrates how to use the serverless CA with PKINIT certificate profiles for Kerberos authentication.
+
+## Overview
+
+PKINIT (Public Key Cryptography for Initial Authentication in Kerberos) allows Kerberos authentication using X.509 certificates instead of passwords. This example shows how to configure the serverless CA to issue PKINIT-compatible certificates.
+
+## Features
+
+- **PKINIT KDC Certificates**: Certificates for Kerberos Key Distribution Centers
+- **PKINIT Client Certificates**: Certificates for Kerberos clients
+- **Enhanced TLS Server Certificates**: Additional server certificate profiles
+- **Custom Certificate Policies**: PKINIT-specific OIDs and extensions
+
+## Certificate Profiles
+
+### PKINIT KDC Profile (`pkinit_kdc`)
+- **Purpose**: Certificates for Kerberos KDC servers
+- **Key Usage**: Digital signature only (no key encipherment)
+- **Extended Key Usage**: Client and server authentication
+- **Certificate Policy**: `1.3.6.1.5.2.3.5` (PKINIT KDC OID)
+- **Lifetime**: 10 years (3650 days)
+- **Common Name**: Must be in format `krbtgt/REALM@REALM`
+
+### PKINIT Client Profile (`pkinit_client`)
+- **Purpose**: Certificates for Kerberos clients
+- **Key Usage**: Digital signature only
+- **Extended Key Usage**: Client authentication
+- **Certificate Policy**: `1.3.6.1.5.2.3.5` (PKINIT OID)
+- **Lifetime**: 1 year (365 days)
+- **Common Name**: Should be in format `user@REALM` or `service@REALM`
+
+## Usage
+
+1. **Deploy the CA with PKINIT profiles**:
+   ```bash
+   terraform init
+   terraform apply
+   ```
+
+2. **Start the CA**:
+   - Execute the Step Function in AWS Console
+   - Or wait for the scheduled run
+
+3. **Issue PKINIT certificates**:
+   - The example includes JSON files for KDC and client certificates
+   - Certificates will be issued automatically via the Step Function
+
+## Certificate Examples
+
+### KDC Certificate
+```json
+{
+  "common_name": "krbtgt/EXAMPLE.COM@EXAMPLE.COM",
+  "organization": "Example Corp",
+  "organizational_unit": "IT Department",
+  "country": "US",
+  "state": "California",
+  "locality": "San Francisco",
+  "lifetime": 3650,
+  "profile": "pkinit_kdc",
+  "force_issue": true
+}
+```
+
+### Client Certificate
+```json
+{
+  "common_name": "user@EXAMPLE.COM",
+  "organization": "Example Corp",
+  "organizational_unit": "IT Department",
+  "country": "US",
+  "state": "California",
+  "locality": "San Francisco",
+  "lifetime": 365,
+  "profile": "pkinit_client",
+  "force_issue": true
+}
+```
+
+## Integration with FreeIPA
+
+This implementation follows the [FreeIPA PKINIT specification](https://www.freeipa.org/page/V4/Kerberos_PKINIT) and provides:
+
+- **KDC Certificates**: Compatible with FreeIPA KDC configuration
+- **Client Certificates**: Support for user and service principal authentication
+- **Certificate Policies**: Proper OIDs for PKINIT validation
+- **Subject Alternative Names**: Kerberos principal names in SAN extensions
+
+## Customization
+
+You can customize the certificate profiles by modifying the `certificate_profiles` variable in `ca.tf`:
+
+```hcl
+certificate_profiles = {
+  "custom_pkinit" = {
+    description = "Custom PKINIT profile"
+    key_usage = {
+      digital_signature = true
+      # ... other key usage settings
+    }
+    extended_key_usage = ["client_auth"]
+    certificate_policies = ["1.3.6.1.5.2.3.5"]
+    lifetime_days = 365
+    # ... other settings
+  }
+}
+```
+
+## Security Considerations
+
+- **Key Usage**: PKINIT certificates should only allow digital signature, not key encipherment
+- **Certificate Policies**: Use the correct PKINIT OID (`1.3.6.1.5.2.3.5`)
+- **Lifetime**: KDC certificates can have longer lifetimes than client certificates
+- **Principal Names**: Ensure common names follow Kerberos principal naming conventions
+
+## Troubleshooting
+
+1. **Profile not found**: Ensure the profile name matches exactly in the certificate request
+2. **Invalid extensions**: Check that the profile configuration includes required PKINIT extensions
+3. **Certificate validation**: Verify that the issued certificates include the correct OIDs and extensions

--- a/examples/pkinit/ca.tf
+++ b/examples/pkinit/ca.tf
@@ -1,0 +1,76 @@
+module "certificate_authority" {
+  source = "../../"
+  # source  = "serverless-ca/ca/aws"
+  # version = "1.0.0"
+
+  # Enable PKINIT certificate profiles
+  certificate_profiles = {
+    "pkinit_kdc" = {
+      description = "PKINIT KDC certificate for Kerberos authentication"
+      key_usage = {
+        digital_signature = true
+        key_encipherment  = false
+        data_encipherment = false
+        key_agreement     = false
+        key_cert_sign     = false
+        crl_sign          = false
+        content_commitment = false
+        encipher_only     = false
+        decipher_only     = false
+      }
+      extended_key_usage = ["client_auth", "server_auth"]
+      certificate_policies = ["1.3.6.1.5.2.3.5"]  # PKINIT KDC OID
+      lifetime_days = 3650  # 10 years for KDC certificates
+      max_lifetime_days = 3650
+      require_common_name = true
+    }
+    
+    "pkinit_client" = {
+      description = "PKINIT client certificate for Kerberos authentication"
+      key_usage = {
+        digital_signature = true
+        key_encipherment  = false
+        data_encipherment = false
+        key_agreement     = false
+        key_cert_sign     = false
+        crl_sign          = false
+        content_commitment = false
+        encipher_only     = false
+        decipher_only     = false
+      }
+      extended_key_usage = ["client_auth"]
+      certificate_policies = ["1.3.6.1.5.2.3.5"]  # PKINIT OID
+      lifetime_days = 365
+      max_lifetime_days = 365
+      require_common_name = true
+    }
+    
+    "tls_server_enhanced" = {
+      description = "Enhanced TLS server certificate with additional extensions"
+      key_usage = {
+        digital_signature = true
+        key_encipherment  = true
+        data_encipherment = false
+        key_agreement     = false
+        key_cert_sign     = false
+        crl_sign          = false
+        content_commitment = false
+        encipher_only     = false
+        decipher_only     = false
+      }
+      extended_key_usage = ["server_auth", "client_auth"]
+      certificate_policies = ["2.23.140.1.2.1"]  # DV Certificate Policy
+      lifetime_days = 365
+      max_lifetime_days = 365
+      allow_wildcard_sans = true
+    }
+  }
+
+  # Example certificate info files for PKINIT
+  cert_info_files = ["pkinit-kdc", "pkinit-client"]
+
+  providers = {
+    aws           = aws
+    aws.us-east-1 = aws.us-east-1 # required even if CloudFront not used
+  }
+}

--- a/examples/pkinit/certs/dev/pkinit-client.json
+++ b/examples/pkinit/certs/dev/pkinit-client.json
@@ -1,0 +1,24 @@
+[
+  {
+    "common_name": "user@EXAMPLE.COM",
+    "organization": "Example Corp",
+    "organizational_unit": "IT Department",
+    "country": "US",
+    "state": "California",
+    "locality": "San Francisco",
+    "lifetime": 365,
+    "profile": "pkinit_client",
+    "force_issue": true
+  },
+  {
+    "common_name": "service@EXAMPLE.COM",
+    "organization": "Example Corp",
+    "organizational_unit": "IT Department",
+    "country": "US",
+    "state": "California",
+    "locality": "San Francisco",
+    "lifetime": 365,
+    "profile": "pkinit_client",
+    "force_issue": true
+  }
+]

--- a/examples/pkinit/certs/dev/pkinit-kdc.json
+++ b/examples/pkinit/certs/dev/pkinit-kdc.json
@@ -1,0 +1,13 @@
+[
+  {
+    "common_name": "krbtgt/EXAMPLE.COM@EXAMPLE.COM",
+    "organization": "Example Corp",
+    "organizational_unit": "IT Department",
+    "country": "US",
+    "state": "California",
+    "locality": "San Francisco",
+    "lifetime": 3650,
+    "profile": "pkinit_kdc",
+    "force_issue": true
+  }
+]

--- a/main.tf
+++ b/main.tf
@@ -213,6 +213,7 @@ module "create_rsa_root_ca_lambda" {
   public_crl                      = var.public_crl
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
   xray_enabled                    = var.xray_enabled
+  certificate_profiles            = var.certificate_profiles
   tags                            = merge(var.tags, var.additional_lambda_tags)
 }
 
@@ -237,6 +238,7 @@ module "create_rsa_issuing_ca_lambda" {
   public_crl                      = var.public_crl
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
   xray_enabled                    = var.xray_enabled
+  certificate_profiles            = var.certificate_profiles
   tags                            = merge(var.tags, var.additional_lambda_tags)
 }
 
@@ -263,6 +265,7 @@ module "rsa_root_ca_crl_lambda" {
   public_crl                      = var.public_crl
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
   xray_enabled                    = var.xray_enabled
+  certificate_profiles            = var.certificate_profiles
   tags                            = merge(var.tags, var.additional_lambda_tags)
 }
 
@@ -289,6 +292,7 @@ module "rsa_issuing_ca_crl_lambda" {
   public_crl                      = var.public_crl
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
   xray_enabled                    = var.xray_enabled
+  certificate_profiles            = var.certificate_profiles
   tags                            = merge(var.tags, var.additional_lambda_tags)
 }
 
@@ -315,6 +319,7 @@ module "rsa_tls_cert_lambda" {
   allowed_invocation_principals   = var.aws_principals
   sns_topic_arn                   = module.sns_ca_notifications.sns_topic_arn
   xray_enabled                    = var.xray_enabled
+  certificate_profiles            = var.certificate_profiles
   tags                            = merge(var.tags, var.additional_lambda_tags)
 }
 

--- a/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
+++ b/modules/terraform-aws-ca-lambda/lambda_code/tls_cert/tls_cert.py
@@ -48,6 +48,7 @@ class Request:
     force_issue: Optional[bool] = False
     cert_bundle: Optional[bool] = False
     ca_chain_only: Optional[bool] = False
+    profile: Optional[str] = None  # Certificate profile name
 
 
 @dataclass_json(letter_case=LetterCase.PASCAL)
@@ -187,10 +188,11 @@ def create_csr_info(event) -> CsrInfo:
     lifetime = int(event.get("lifetime", 30))
     purposes = event.get("purposes")
     sans = event.get("sans")
+    profile = event.get("profile")
 
     subject = create_csr_subject(event)
 
-    csr_info = CsrInfo(subject, lifetime=lifetime, purposes=purposes, sans=sans)
+    csr_info = CsrInfo(subject, lifetime=lifetime, purposes=purposes, sans=sans, profile=profile)
 
     return csr_info
 

--- a/modules/terraform-aws-ca-lambda/main.tf
+++ b/modules/terraform-aws-ca-lambda/main.tf
@@ -64,6 +64,7 @@ resource "aws_lambda_function" "lambda" {
       ROOT_CRL_DAYS       = tostring(var.root_crl_days)
       ROOT_CRL_SECONDS    = tostring(var.root_crl_seconds)
       SNS_TOPIC_ARN       = var.sns_topic_arn
+      CERTIFICATE_PROFILES = jsonencode(var.certificate_profiles)
     }
   }
 

--- a/modules/terraform-aws-ca-lambda/utils/certs/crypto.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/crypto.py
@@ -36,6 +36,7 @@ def crypto_cert_request_info(csr_cert, csr_info):
     # get values from csr_info
     purposes = csr_info.purposes
     sans = csr_info.sans
+    profile = csr_info.profile
 
     # convert to x509 cryptography format
     x509_sans = []
@@ -54,6 +55,7 @@ def crypto_cert_request_info(csr_cert, csr_info):
         "Purposes": purposes,
         "State": csr_info.subject.state,
         "x509Sans": x509_sans,
+        "Profile": profile,
     }
 
 

--- a/modules/terraform-aws-ca-lambda/utils/certs/profiles.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/profiles.py
@@ -1,0 +1,394 @@
+"""
+Certificate Profile System
+
+This module implements a flexible certificate profile system that allows
+issuing certificates with specific extensions and constraints for different
+use cases, such as PKINIT, TLS, etc.
+"""
+
+import os
+import json
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass, field
+from cryptography import x509
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+from cryptography.x509 import (
+    AccessDescription,
+    UniformResourceIdentifier,
+    PolicyInformation,
+    ObjectIdentifier,
+    OtherName,
+    GeneralName,
+)
+from cryptography.x509.oid import AuthorityInformationAccessOID
+
+
+@dataclass
+class CertificateProfile:
+    """Defines a certificate profile with specific extensions and constraints"""
+    name: str
+    description: str
+    key_usage: Dict[str, bool] = field(default_factory=dict)
+    extended_key_usage: List[str] = field(default_factory=list)
+    basic_constraints: Optional[Dict[str, Any]] = None
+    subject_alt_names: Optional[List[str]] = None
+    certificate_policies: Optional[List[str]] = None
+    crl_distribution_points: Optional[List[str]] = None
+    authority_info_access: Optional[List[Dict[str, str]]] = None
+    custom_extensions: Optional[List[Dict[str, Any]]] = None
+    lifetime_days: Optional[int] = None
+    max_lifetime_days: Optional[int] = None
+    require_common_name: bool = True
+    allow_wildcard_sans: bool = False
+
+
+class ProfileManager:
+    """Manages certificate profiles and their configurations"""
+    
+    def __init__(self):
+        self.profiles: Dict[str, CertificateProfile] = {}
+        self._load_default_profiles()
+        self._load_custom_profiles()
+    
+    def _load_default_profiles(self):
+        """Load default certificate profiles"""
+        # TLS Client Profile
+        self.profiles["tls_client"] = CertificateProfile(
+            name="tls_client",
+            description="Standard TLS client certificate",
+            key_usage={
+                "digital_signature": True,
+                "key_encipherment": True,
+                "data_encipherment": False,
+                "key_agreement": False,
+                "key_cert_sign": False,
+                "crl_sign": False,
+                "content_commitment": False,
+                "encipher_only": False,
+                "decipher_only": False,
+            },
+            extended_key_usage=["client_auth"],
+            certificate_policies=["2.23.140.1.2.1"],  # DV Certificate Policy
+            lifetime_days=365,
+            max_lifetime_days=365,
+        )
+        
+        # TLS Server Profile
+        self.profiles["tls_server"] = CertificateProfile(
+            name="tls_server",
+            description="Standard TLS server certificate",
+            key_usage={
+                "digital_signature": True,
+                "key_encipherment": True,
+                "data_encipherment": False,
+                "key_agreement": False,
+                "key_cert_sign": False,
+                "crl_sign": False,
+                "content_commitment": False,
+                "encipher_only": False,
+                "decipher_only": False,
+            },
+            extended_key_usage=["server_auth"],
+            certificate_policies=["2.23.140.1.2.1"],  # DV Certificate Policy
+            lifetime_days=365,
+            max_lifetime_days=365,
+            allow_wildcard_sans=True,
+        )
+        
+        # PKINIT KDC Profile (based on FreeIPA requirements)
+        self.profiles["pkinit_kdc"] = CertificateProfile(
+            name="pkinit_kdc",
+            description="PKINIT KDC certificate for Kerberos authentication",
+            key_usage={
+                "digital_signature": True,
+                "key_encipherment": False,
+                "data_encipherment": False,
+                "key_agreement": False,
+                "key_cert_sign": False,
+                "crl_sign": False,
+                "content_commitment": False,
+                "encipher_only": False,
+                "decipher_only": False,
+            },
+            extended_key_usage=["client_auth", "server_auth"],
+            certificate_policies=["1.3.6.1.5.2.3.5"],  # PKINIT KDC OID
+            lifetime_days=3650,  # 10 years for KDC certificates
+            max_lifetime_days=3650,
+            require_common_name=True,
+        )
+        
+        # PKINIT Client Profile
+        self.profiles["pkinit_client"] = CertificateProfile(
+            name="pkinit_client",
+            description="PKINIT client certificate for Kerberos authentication",
+            key_usage={
+                "digital_signature": True,
+                "key_encipherment": False,
+                "data_encipherment": False,
+                "key_agreement": False,
+                "key_cert_sign": False,
+                "crl_sign": False,
+                "content_commitment": False,
+                "encipher_only": False,
+                "decipher_only": False,
+            },
+            extended_key_usage=["client_auth"],
+            certificate_policies=["1.3.6.1.5.2.3.5"],  # PKINIT OID
+            lifetime_days=365,
+            max_lifetime_days=365,
+            require_common_name=True,
+        )
+        
+        # CA Profile
+        self.profiles["ca"] = CertificateProfile(
+            name="ca",
+            description="Certificate Authority certificate",
+            key_usage={
+                "digital_signature": True,
+                "key_encipherment": False,
+                "data_encipherment": False,
+                "key_agreement": False,
+                "key_cert_sign": True,
+                "crl_sign": True,
+                "content_commitment": False,
+                "encipher_only": False,
+                "decipher_only": False,
+            },
+            basic_constraints={"ca": True, "path_length": None},
+            lifetime_days=7300,  # 20 years for CA certificates
+            max_lifetime_days=7300,
+        )
+    
+    def get_profile(self, profile_name: str) -> Optional[CertificateProfile]:
+        """Get a certificate profile by name"""
+        return self.profiles.get(profile_name)
+    
+    def list_profiles(self) -> List[str]:
+        """List all available profile names"""
+        return list(self.profiles.keys())
+    
+    def add_profile(self, profile: CertificateProfile):
+        """Add a custom profile"""
+        self.profiles[profile.name] = profile
+    
+    def _load_custom_profiles(self):
+        """Load custom profiles from environment variables"""
+        import os
+        import json
+        
+        profiles_json = os.environ.get("CERTIFICATE_PROFILES", "{}")
+        if profiles_json:
+            try:
+                custom_profiles = json.loads(profiles_json)
+                self.load_profiles_from_config(custom_profiles)
+                print(f"Loaded {len(custom_profiles)} custom certificate profiles")
+            except json.JSONDecodeError as e:
+                print(f"Warning: Failed to parse CERTIFICATE_PROFILES: {e}")
+    
+    def load_profiles_from_config(self, config: Dict[str, Any]):
+        """Load profiles from configuration dictionary"""
+        for profile_name, profile_config in config.items():
+            profile = CertificateProfile(
+                name=profile_name,
+                **profile_config
+            )
+            self.profiles[profile_name] = profile
+
+
+def create_key_usage_extension(profile: CertificateProfile) -> x509.KeyUsage:
+    """Create KeyUsage extension from profile"""
+    return x509.KeyUsage(
+        digital_signature=profile.key_usage.get("digital_signature", False),
+        key_cert_sign=profile.key_usage.get("key_cert_sign", False),
+        crl_sign=profile.key_usage.get("crl_sign", False),
+        content_commitment=profile.key_usage.get("content_commitment", False),
+        key_encipherment=profile.key_usage.get("key_encipherment", False),
+        data_encipherment=profile.key_usage.get("data_encipherment", False),
+        key_agreement=profile.key_usage.get("key_agreement", False),
+        encipher_only=profile.key_usage.get("encipher_only", False),
+        decipher_only=profile.key_usage.get("decipher_only", False),
+    )
+
+
+def create_extended_key_usage_extension(profile: CertificateProfile) -> Optional[x509.ExtendedKeyUsage]:
+    """Create ExtendedKeyUsage extension from profile"""
+    if not profile.extended_key_usage:
+        return None
+    
+    oids = []
+    for usage in profile.extended_key_usage:
+        if usage == "client_auth":
+            oids.append(ExtendedKeyUsageOID.CLIENT_AUTH)
+        elif usage == "server_auth":
+            oids.append(ExtendedKeyUsageOID.SERVER_AUTH)
+        elif usage == "code_signing":
+            oids.append(ExtendedKeyUsageOID.CODE_SIGNING)
+        elif usage == "email_protection":
+            oids.append(ExtendedKeyUsageOID.EMAIL_PROTECTION)
+        elif usage == "time_stamping":
+            oids.append(ExtendedKeyUsageOID.TIME_STAMPING)
+        elif usage == "ocsp_signing":
+            oids.append(ExtendedKeyUsageOID.OCSP_SIGNING)
+    
+    return x509.ExtendedKeyUsage(oids) if oids else None
+
+
+def create_basic_constraints_extension(profile: CertificateProfile) -> Optional[x509.BasicConstraints]:
+    """Create BasicConstraints extension from profile"""
+    if not profile.basic_constraints:
+        return None
+    
+    return x509.BasicConstraints(
+        ca=profile.basic_constraints.get("ca", False),
+        path_length=profile.basic_constraints.get("path_length"),
+    )
+
+
+def create_certificate_policies_extension(profile: CertificateProfile) -> Optional[x509.CertificatePolicies]:
+    """Create CertificatePolicies extension from profile"""
+    if not profile.certificate_policies:
+        return None
+    
+    policies = []
+    for policy_oid in profile.certificate_policies:
+        policies.append(PolicyInformation(ObjectIdentifier(policy_oid), None))
+    
+    return x509.CertificatePolicies(policies) if policies else None
+
+
+def create_crl_distribution_points_extension(profile: CertificateProfile, domain: str = None) -> Optional[x509.CRLDistributionPoints]:
+    """Create CRLDistributionPoints extension from profile"""
+    if not profile.crl_distribution_points:
+        return None
+    
+    distribution_points = []
+    for crl_url in profile.crl_distribution_points:
+        if domain and "{domain}" in crl_url:
+            crl_url = crl_url.format(domain=domain)
+        distribution_points.append(
+            x509.DistributionPoint(
+                [UniformResourceIdentifier(crl_url)],
+                relative_name=None,
+                reasons=None,
+                crl_issuer=None,
+            )
+        )
+    
+    return x509.CRLDistributionPoints(distribution_points) if distribution_points else None
+
+
+def create_authority_info_access_extension(profile: CertificateProfile, domain: str = None) -> Optional[x509.AuthorityInformationAccess]:
+    """Create AuthorityInformationAccess extension from profile"""
+    if not profile.authority_info_access:
+        return None
+    
+    access_descriptions = []
+    for aia in profile.authority_info_access:
+        if domain and "{domain}" in aia["url"]:
+            aia["url"] = aia["url"].format(domain=domain)
+        
+        if aia["access_method"] == "ca_issuers":
+            access_descriptions.append(
+                AccessDescription(
+                    AuthorityInformationAccessOID.CA_ISSUERS,
+                    UniformResourceIdentifier(aia["url"]),
+                )
+            )
+        elif aia["access_method"] == "ocsp":
+            access_descriptions.append(
+                AccessDescription(
+                    AuthorityInformationAccessOID.OCSP,
+                    UniformResourceIdentifier(aia["url"]),
+                )
+            )
+    
+    return x509.AuthorityInformationAccess(access_descriptions) if access_descriptions else None
+
+
+def create_subject_alt_names_extension(profile: CertificateProfile, sans: List[str] = None) -> Optional[x509.SubjectAlternativeName]:
+    """Create SubjectAlternativeName extension from profile"""
+    if not profile.subject_alt_names and not sans:
+        return None
+    
+    alt_names = []
+    all_sans = (profile.subject_alt_names or []) + (sans or [])
+    
+    for san in all_sans:
+        if san.startswith("DNS:"):
+            alt_names.append(x509.DNSName(san[4:]))
+        elif san.startswith("IP:"):
+            alt_names.append(x509.IPAddress(san[3:]))
+        elif san.startswith("EMAIL:"):
+            alt_names.append(x509.RFC822Name(san[6:]))
+        elif san.startswith("URI:"):
+            alt_names.append(x509.UniformResourceIdentifier(san[4:]))
+        else:
+            # Default to DNS name
+            alt_names.append(x509.DNSName(san))
+    
+    return x509.SubjectAlternativeName(alt_names) if alt_names else None
+
+
+def create_pkinit_principal_san(principal: str) -> x509.SubjectAlternativeName:
+    """Create SubjectAlternativeName extension for PKINIT principal"""
+    # PKINIT requires the Kerberos principal in the SAN as an OtherName
+    # OID 1.3.6.1.5.2.2 is for Kerberos principal names
+    kerberos_principal_oid = ObjectIdentifier("1.3.6.1.5.2.2")
+    
+    # Encode the principal as UTF-8 bytes
+    principal_bytes = principal.encode('utf-8')
+    
+    other_name = OtherName(kerberos_principal_oid, principal_bytes)
+    
+    return x509.SubjectAlternativeName([other_name])
+
+
+def apply_profile_to_certificate_builder(
+    builder: x509.CertificateBuilder,
+    profile: CertificateProfile,
+    domain: str = None,
+    sans: List[str] = None
+) -> x509.CertificateBuilder:
+    """Apply profile extensions to a certificate builder"""
+    
+    # Key Usage (critical)
+    builder = builder.add_extension(
+        create_key_usage_extension(profile),
+        critical=True
+    )
+    
+    # Extended Key Usage
+    ext_key_usage = create_extended_key_usage_extension(profile)
+    if ext_key_usage:
+        builder = builder.add_extension(ext_key_usage, critical=False)
+    
+    # Basic Constraints
+    basic_constraints = create_basic_constraints_extension(profile)
+    if basic_constraints:
+        builder = builder.add_extension(basic_constraints, critical=True)
+    
+    # Certificate Policies
+    cert_policies = create_certificate_policies_extension(profile)
+    if cert_policies:
+        builder = builder.add_extension(cert_policies, critical=False)
+    
+    # CRL Distribution Points
+    crl_dp = create_crl_distribution_points_extension(profile, domain)
+    if crl_dp:
+        builder = builder.add_extension(crl_dp, critical=False)
+    
+    # Authority Information Access
+    aia = create_authority_info_access_extension(profile, domain)
+    if aia:
+        builder = builder.add_extension(aia, critical=False)
+    
+    # Subject Alternative Names
+    san_ext = create_subject_alt_names_extension(profile, sans)
+    if san_ext:
+        builder = builder.add_extension(san_ext, critical=False)
+    
+    return builder
+
+
+# Global profile manager instance
+profile_manager = ProfileManager()

--- a/modules/terraform-aws-ca-lambda/utils/certs/types.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/types.py
@@ -100,6 +100,7 @@ def filter_and_validate_sans(common_name: str, sans: list[str]) -> list[str]:
 class CsrInfo:
     subject: Subject
     lifetime: int = 30
+    profile: Optional[str] = None  # Certificate profile name
 
     sans: list[str] = field(init=True, repr=True, default_factory=list)
     _sans: list[str] = field(init=False, repr=False)

--- a/modules/terraform-aws-ca-lambda/variables.tf
+++ b/modules/terraform-aws-ca-lambda/variables.tf
@@ -137,3 +137,9 @@ variable "xray_enabled" {
   description = "Whether to enable active tracing with AWS X-Ray"
   default     = true
 }
+
+variable "certificate_profiles" {
+  description = "Custom certificate profiles for different use cases"
+  type        = map(any)
+  default     = {}
+}

--- a/utils/pkinit-cert.py
+++ b/utils/pkinit-cert.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+PKINIT Certificate Generator
+
+This script generates PKINIT certificates using the serverless CA with
+appropriate profiles for Kerberos authentication.
+"""
+
+import os
+import sys
+import json
+import base64
+import argparse
+import boto3
+from cryptography.hazmat.primitives.serialization import load_der_private_key
+from modules.certs.crypto import create_csr_info, crypto_encode_private_key, crypto_tls_cert_signing_request
+from modules.certs.kms import kms_generate_key_pair, kms_get_kms_key_id
+from modules.aws.lambdas import get_lambda_name
+
+# identify home directory and create certs subdirectory if needed
+homedir = os.path.expanduser("~")
+base_path = f"{homedir}/certs"
+if not os.path.exists(base_path):
+    print(f"Creating directory {base_path}")
+    os.makedirs(base_path)
+
+
+def create_session(profile):
+    """
+    Creates and returns AWS session using profile
+    """
+    try:
+        if profile is not None:
+            session = boto3.session.Session(profile_name=profile)
+        else:
+            session = boto3.session.Session()
+    except Exception as e:
+        session = {"error": e}
+    if isinstance(session, dict):
+        print(f"Error: Unable to open session using profile {profile}. {session['error']}")
+        sys.exit(1)
+    else:
+        print(f"AWS session opened using profile: {profile}")
+    return session
+
+
+def parse_arguments():
+    """
+    Read arguments and return arguments dictionary
+    """
+    parser = argparse.ArgumentParser(description="Generate PKINIT certificates using serverless CA")
+    parser.add_argument("--profile", default=None, help="AWS profile described in .aws/config file")
+    parser.add_argument("--verbose", action="store_true", help="Output of all generated payload data")
+    parser.add_argument("--type", choices=["kdc", "client"], required=True, 
+                       help="Type of PKINIT certificate to generate")
+    parser.add_argument("--principal", required=True, 
+                       help="Kerberos principal name (e.g., krbtgt/EXAMPLE.COM@EXAMPLE.COM or user@EXAMPLE.COM)")
+    parser.add_argument("--organization", default="Example Corp", 
+                       help="Organization name")
+    parser.add_argument("--organizational-unit", default="IT Department", 
+                       help="Organizational unit name")
+    parser.add_argument("--country", default="US", 
+                       help="Country code")
+    parser.add_argument("--state", default="California", 
+                       help="State or province")
+    parser.add_argument("--locality", default="San Francisco", 
+                       help="Locality or city")
+    parser.add_argument("--lifetime", type=int, default=365, 
+                       help="Certificate lifetime in days (default: 365 for client, 3650 for KDC)")
+    parser.add_argument("--output-prefix", default="pkinit", 
+                       help="Output file prefix")
+    
+    return vars(parser.parse_args())
+
+
+def validate_principal(principal, cert_type):
+    """
+    Validate Kerberos principal format
+    """
+    if cert_type == "kdc":
+        if not principal.startswith("krbtgt/") or "@" not in principal:
+            print("Error: KDC principal must be in format 'krbtgt/REALM@REALM'")
+            sys.exit(1)
+    elif cert_type == "client":
+        if "@" not in principal:
+            print("Error: Client principal must be in format 'user@REALM' or 'service@REALM'")
+            sys.exit(1)
+
+
+def main():
+    """
+    Generate PKINIT certificate for specified type and principal
+    """
+    args = parse_arguments()
+    
+    # Validate principal format
+    validate_principal(args["principal"], args["type"])
+    
+    # Set default lifetime for KDC certificates
+    if args["type"] == "kdc" and args["lifetime"] == 365:
+        args["lifetime"] = 3650
+    
+    # create AWS session
+    session = create_session(args["profile"])
+    
+    # Set variables based on certificate type
+    if args["type"] == "kdc":
+        profile_name = "pkinit_kdc"
+        purposes = ["client_auth", "server_auth"]
+        output_suffix = "kdc"
+    else:  # client
+        profile_name = "pkinit_client"
+        purposes = ["client_auth"]
+        output_suffix = "client"
+    
+    # Output file paths
+    output_path_cert_key = f"{base_path}/{args['output_prefix']}-{output_suffix}-key.pem"
+    output_path_cert_pem = f"{base_path}/{args['output_prefix']}-{output_suffix}-cert.pem"
+    output_path_cert_crt = f"{base_path}/{args['output_prefix']}-{output_suffix}-cert.crt"
+    output_path_cert_combined = f"{base_path}/{args['output_prefix']}-{output_suffix}-combined.pem"
+    
+    # KMS key alias (adjust based on your environment)
+    key_alias = "serverless-tls-keygen-dev"
+    
+    # create key pair using symmetric KMS key to provide entropy
+    key_id = kms_get_kms_key_id(key_alias, session=session)
+    if isinstance(key_id, dict):
+        print(f'Error: {key_id["error"]}')
+        sys.exit(1)
+    kms_response = kms_generate_key_pair(key_id, session=session)
+    private_key = load_der_private_key(kms_response["PrivateKeyPlaintext"], None)
+    
+    # create CSR
+    csr_info = create_csr_info(
+        args["principal"], 
+        args["country"], 
+        args["locality"], 
+        args["organization"], 
+        args["organizational_unit"], 
+        args["state"]
+    )
+    csr_pem = crypto_tls_cert_signing_request(private_key, csr_info)
+    
+    # Construct JSON data to pass to Lambda function
+    request_payload = {
+        "common_name": args["principal"],
+        "purposes": purposes,
+        "lifetime": args["lifetime"],
+        "base64_csr_data": base64.b64encode(csr_pem).decode("utf-8"),
+        "force_issue": True,
+        "cert_bundle": True,
+        "profile": profile_name,
+        "organization": args["organization"],
+        "organizational_unit": args["organizational_unit"],
+        "country": args["country"],
+        "state": args["state"],
+        "locality": args["locality"]
+    }
+    
+    request_payload_bytes = json.dumps(request_payload)
+    
+    # Invoke TLS certificate Lambda function
+    lambda_name = get_lambda_name("tls-cert", session=session)
+    client = session.client("lambda")
+    response = client.invoke(
+        FunctionName=lambda_name,
+        InvocationType="RequestResponse",
+        LogType="None",
+        Payload=bytes(request_payload_bytes.encode("utf-8")),
+    )
+    
+    # Inspect the response which includes the signed certificate
+    response_payload = response["Payload"]
+    payload_data = json.load(response_payload)
+    print(f"PKINIT {args['type']} certificate issued for {args['principal']}")
+    if args["verbose"]:
+        print(payload_data)
+    
+    # Extract certificate and private key from response
+    base64_cert_data = payload_data["Base64Certificate"]
+    cert_data = base64.b64decode(base64_cert_data)
+    key_data = crypto_encode_private_key(private_key)
+    
+    # Write certificate and private key to files
+    if output_path_cert_key:
+        with open(output_path_cert_key, "w", encoding="utf-8") as f:
+            f.write(key_data.decode("utf-8"))
+            print(f"Private key written to {output_path_cert_key}")
+    
+    if output_path_cert_pem:
+        with open(output_path_cert_pem, "w", encoding="utf-8") as f:
+            f.write(cert_data.decode("utf-8"))
+            print(f"PKINIT {args['type']} certificate and CA bundle written to {output_path_cert_pem}")
+    
+    if output_path_cert_crt:
+        with open(output_path_cert_crt, "w", encoding="utf-8") as f:
+            f.write(cert_data.decode("utf-8"))
+            print(f"Certificate written to {output_path_cert_crt}")
+    
+    if output_path_cert_combined:
+        with open(output_path_cert_combined, "w", encoding="utf-8") as f:
+            f.write(key_data.decode("utf-8"))
+            f.write(cert_data.decode("utf-8"))
+            print(f"Combined private key and certificate written to {output_path_cert_combined}")
+    
+    print(f"\nPKINIT {args['type']} certificate generation completed!")
+    print(f"Principal: {args['principal']}")
+    print(f"Profile: {profile_name}")
+    print(f"Lifetime: {args['lifetime']} days")
+    print(f"Files created in: {base_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/variables.tf
+++ b/variables.tf
@@ -370,3 +370,23 @@ variable "xray_enabled" {
   description = "Whether to enable active tracing with AWS X-Ray"
   default     = true
 }
+
+variable "certificate_profiles" {
+  type = map(object({
+    description                = string
+    key_usage                  = optional(map(bool), {})
+    extended_key_usage         = optional(list(string), [])
+    basic_constraints          = optional(map(any), null)
+    subject_alt_names          = optional(list(string), null)
+    certificate_policies       = optional(list(string), null)
+    crl_distribution_points    = optional(list(string), null)
+    authority_info_access      = optional(list(map(string)), null)
+    custom_extensions          = optional(list(map(any)), null)
+    lifetime_days              = optional(number, null)
+    max_lifetime_days          = optional(number, null)
+    require_common_name        = optional(bool, true)
+    allow_wildcard_sans        = optional(bool, false)
+  }))
+  description = "Custom certificate profiles for different use cases (e.g., PKINIT, TLS, etc.)"
+  default     = {}
+}


### PR DESCRIPTION
# Summary:
This PR introduces a flexible certificate profile system that allows issuing certificates with specific extensions and constraints for different use cases, with built-in support for PKINIT certificates following the FreeIPA specification.

# Key Features:
## Certificate Profile System
- Flexible Profile Engine: Dynamic profile loading with support for custom configurations
- Built-in Profiles: Pre-configured profiles for common use cases (TLS, PKINIT, CA)
- Custom Profiles: Terraform-configurable profiles for specialized requirements
- Backward Compatibility: Existing functionality remains unchanged

## PKINIT Support
- Based on FreeIPA PKINIT specification:
- PKINIT KDC Profile: Certificates for Kerberos Key Distribution Centers
- PKINIT Client Profile: Certificates for Kerberos client authentication
- Proper OIDs: Uses correct PKINIT OID (1.3.6.1.5.2.3.5)
- Kerberos Principal Names: Includes principals in Subject Alternative Names
- Appropriate Lifetimes: 10 years for KDC, 1 year for client certificates