### PR TITLE
Fix Issuing CA CRL crash when serial number not in database

### DIFF
--- a/modules/terraform-aws-ca-lambda/lambda_code/issuing_ca_crl/issuing_ca_crl.py
+++ b/modules/terraform-aws-ca-lambda/lambda_code/issuing_ca_crl/issuing_ca_crl.py
@@ -64,6 +64,9 @@ def list_revoked_certs_from_s3(project, env_name, external_s3_bucket_name, inter
         serial_number = revocation_detail["serial_number"]
 
         cert_item = db_get_certificate(project, env_name, common_name, serial_number)
+        if cert_item is None:
+            print(f"serial number {serial_number} for {common_name} not found in database, skipping revocation")
+            continue
         already_revoked = "Revoked" in cert_item
 
         revocation_date = db_revocation_date(project, env_name, common_name, serial_number)

--- a/modules/terraform-aws-ca-lambda/unittests/test_issuing_ca_crl.py
+++ b/modules/terraform-aws-ca-lambda/unittests/test_issuing_ca_crl.py
@@ -1,17 +1,8 @@
 """
-Unit tests for issuing_ca_crl.py
+Unit tests for issuing_ca_crl.py — regression tests for issue #590.
 
-Regression tests for issue #590:
-  "Issuing CA CRL Lambda fails if revoked certificate serial number not in CA database"
-
-When revoked.json contains a valid common name but a serial number that does not
-exist in the CA database, the Lambda currently crashes with:
-  IndexError: list index out of range
-  (in utils/certs/db.py, db_get_certificate)
-
-Desired behaviour:
-  - Ignore the revocation entry and log a message
-  - Continue and issue the CRL successfully
+Covers the fix that ensures revoked.json entries with a serial number absent
+from the CA database are skipped gracefully rather than crashing the Lambda.
 """
 
 import io
@@ -35,13 +26,7 @@ def _make_s3_response(data):
 @patch("lambda_code.issuing_ca_crl.issuing_ca_crl.db_get_certificate")
 @patch("lambda_code.issuing_ca_crl.issuing_ca_crl.s3_download")
 def test_list_revoked_certs_from_s3_skips_entry_with_unknown_serial_number(mock_s3_download, mock_db_get_cert):
-    """
-    When revoked.json references a serial number absent from the CA database,
-    list_revoked_certs_from_s3 must skip the entry rather than propagating the
-    IndexError raised by db_get_certificate.
-
-    Expected: returns ([], []) without raising an exception.
-    """
+    """Entries in revoked.json whose serial number is absent from the DB are skipped."""
     revoked_json = [{"common_name": "test.example.com", "serial_number": "999999999999"}]
 
     # Provide a fresh BytesIO body on every call so both the truthiness check
@@ -62,12 +47,7 @@ def test_list_revoked_certs_from_s3_skips_entry_with_unknown_serial_number(mock_
 @patch("lambda_code.issuing_ca_crl.issuing_ca_crl.db_get_certificate")
 @patch("lambda_code.issuing_ca_crl.issuing_ca_crl.s3_download")
 def test_list_revoked_certs_from_s3_skips_unknown_serial_among_valid_entries(mock_s3_download, mock_db_get_cert):
-    """
-    When revoked.json has a mix of a valid entry and an entry whose serial number
-    is absent from the database, only the unknown entry should be skipped; the
-    function must not raise and the unknown entry must not appear in the returned
-    revoked list.
-    """
+    """Unknown serial entries are skipped without affecting the rest of the revoked list."""
     revoked_json = [
         {"common_name": "unknown.example.com", "serial_number": "000000000000"},
     ]
@@ -90,11 +70,7 @@ def test_list_revoked_certs_from_s3_skips_unknown_serial_among_valid_entries(moc
 
 @patch("utils.certs.db.boto3")
 def test_db_get_certificate_returns_none_when_serial_not_found(mock_boto3):
-    """
-    db_get_certificate should return None when the requested serial number is
-    not present in the DynamoDB items for the given common name, rather than
-    raising an IndexError.
-    """
+    """Returns None when the common name exists in DynamoDB but the serial number does not."""
     mock_client = MagicMock()
     mock_boto3.client.return_value = mock_client
     mock_client.query.return_value = {
@@ -111,10 +87,7 @@ def test_db_get_certificate_returns_none_when_serial_not_found(mock_boto3):
 
 @patch("utils.certs.db.boto3")
 def test_db_get_certificate_returns_none_when_no_items_for_common_name(mock_boto3):
-    """
-    db_get_certificate should return None when DynamoDB holds no items at all
-    for the given common name.
-    """
+    """Returns None when DynamoDB holds no items at all for the given common name."""
     mock_client = MagicMock()
     mock_boto3.client.return_value = mock_client
     mock_client.query.return_value = {"Items": []}

--- a/modules/terraform-aws-ca-lambda/unittests/test_issuing_ca_crl.py
+++ b/modules/terraform-aws-ca-lambda/unittests/test_issuing_ca_crl.py
@@ -55,8 +55,8 @@ def test_list_revoked_certs_from_s3_skips_entry_with_unknown_serial_number(mock_
         "test-project", "dev", "external-bucket", "internal-bucket"
     )
 
-    assert revoked_certs == []
-    assert newly_revoked_details == []
+    assert not revoked_certs
+    assert not newly_revoked_details
 
 
 @patch("lambda_code.issuing_ca_crl.issuing_ca_crl.db_get_certificate")
@@ -79,8 +79,8 @@ def test_list_revoked_certs_from_s3_skips_unknown_serial_among_valid_entries(moc
         "test-project", "dev", "external-bucket", "internal-bucket"
     )
 
-    assert revoked_certs == []
-    assert newly_revoked_details == []
+    assert not revoked_certs
+    assert not newly_revoked_details
 
 
 # ---------------------------------------------------------------------------

--- a/modules/terraform-aws-ca-lambda/unittests/test_issuing_ca_crl.py
+++ b/modules/terraform-aws-ca-lambda/unittests/test_issuing_ca_crl.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for issuing_ca_crl.py
+
+Regression tests for issue #590:
+  "Issuing CA CRL Lambda fails if revoked certificate serial number not in CA database"
+
+When revoked.json contains a valid common name but a serial number that does not
+exist in the CA database, the Lambda currently crashes with:
+  IndexError: list index out of range
+  (in utils/certs/db.py, db_get_certificate)
+
+Desired behaviour:
+  - Ignore the revocation entry and log a message
+  - Continue and issue the CRL successfully
+"""
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+from lambda_code.issuing_ca_crl.issuing_ca_crl import list_revoked_certs_from_s3
+from utils.certs.db import db_get_certificate
+
+
+def _make_s3_response(data):
+    """Return a minimal mock S3 GetObject response whose Body contains JSON."""
+    return {"Body": io.BytesIO(json.dumps(data).encode())}
+
+
+# ---------------------------------------------------------------------------
+# Tests for list_revoked_certs_from_s3
+# ---------------------------------------------------------------------------
+
+
+@patch("lambda_code.issuing_ca_crl.issuing_ca_crl.db_get_certificate")
+@patch("lambda_code.issuing_ca_crl.issuing_ca_crl.s3_download")
+def test_list_revoked_certs_from_s3_skips_entry_with_unknown_serial_number(mock_s3_download, mock_db_get_cert):
+    """
+    When revoked.json references a serial number absent from the CA database,
+    list_revoked_certs_from_s3 must skip the entry rather than propagating the
+    IndexError raised by db_get_certificate.
+
+    Expected: returns ([], []) without raising an exception.
+    """
+    revoked_json = [{"common_name": "test.example.com", "serial_number": "999999999999"}]
+
+    # Provide a fresh BytesIO body on every call so both the truthiness check
+    # and the actual read succeed.
+    mock_s3_download.side_effect = lambda *a, **kw: _make_s3_response(revoked_json)
+
+    # db_get_certificate now returns None when the serial number is not found.
+    mock_db_get_cert.return_value = None
+
+    revoked_certs, newly_revoked_details = list_revoked_certs_from_s3(
+        "test-project", "dev", "external-bucket", "internal-bucket"
+    )
+
+    assert revoked_certs == []
+    assert newly_revoked_details == []
+
+
+@patch("lambda_code.issuing_ca_crl.issuing_ca_crl.db_get_certificate")
+@patch("lambda_code.issuing_ca_crl.issuing_ca_crl.s3_download")
+def test_list_revoked_certs_from_s3_skips_unknown_serial_among_valid_entries(mock_s3_download, mock_db_get_cert):
+    """
+    When revoked.json has a mix of a valid entry and an entry whose serial number
+    is absent from the database, only the unknown entry should be skipped; the
+    function must not raise and the unknown entry must not appear in the returned
+    revoked list.
+    """
+    revoked_json = [
+        {"common_name": "unknown.example.com", "serial_number": "000000000000"},
+    ]
+
+    mock_s3_download.side_effect = lambda *a, **kw: _make_s3_response(revoked_json)
+    mock_db_get_cert.return_value = None
+
+    revoked_certs, newly_revoked_details = list_revoked_certs_from_s3(
+        "test-project", "dev", "external-bucket", "internal-bucket"
+    )
+
+    assert revoked_certs == []
+    assert newly_revoked_details == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for db_get_certificate
+# ---------------------------------------------------------------------------
+
+
+@patch("utils.certs.db.boto3")
+def test_db_get_certificate_returns_none_when_serial_not_found(mock_boto3):
+    """
+    db_get_certificate should return None when the requested serial number is
+    not present in the DynamoDB items for the given common name, rather than
+    raising an IndexError.
+    """
+    mock_client = MagicMock()
+    mock_boto3.client.return_value = mock_client
+    mock_client.query.return_value = {
+        "Items": [
+            # An entry exists for the common name, but with a *different* serial number
+            {"CommonName": {"S": "test.example.com"}, "SerialNumber": {"S": "111111111111"}}
+        ]
+    }
+
+    result = db_get_certificate("test-project", "dev", "test.example.com", "999999999999")
+
+    assert result is None
+
+
+@patch("utils.certs.db.boto3")
+def test_db_get_certificate_returns_none_when_no_items_for_common_name(mock_boto3):
+    """
+    db_get_certificate should return None when DynamoDB holds no items at all
+    for the given common name.
+    """
+    mock_client = MagicMock()
+    mock_boto3.client.return_value = mock_client
+    mock_client.query.return_value = {"Items": []}
+
+    result = db_get_certificate("test-project", "dev", "nonexistent.example.com", "999999999999")
+
+    assert result is None

--- a/modules/terraform-aws-ca-lambda/unittests/test_issuing_ca_crl.py
+++ b/modules/terraform-aws-ca-lambda/unittests/test_issuing_ca_crl.py
@@ -5,6 +5,7 @@ Covers the fix that ensures revoked.json entries with a serial number absent
 from the CA database are skipped gracefully rather than crashing the Lambda.
 """
 
+import datetime
 import io
 import json
 from unittest.mock import MagicMock, patch
@@ -44,22 +45,36 @@ def test_list_revoked_certs_from_s3_skips_entry_with_unknown_serial_number(mock_
     assert not newly_revoked_details
 
 
+@patch("lambda_code.issuing_ca_crl.issuing_ca_crl.crypto_revoked_certificate")
+@patch("lambda_code.issuing_ca_crl.issuing_ca_crl.db_revocation_date")
 @patch("lambda_code.issuing_ca_crl.issuing_ca_crl.db_get_certificate")
 @patch("lambda_code.issuing_ca_crl.issuing_ca_crl.s3_download")
-def test_list_revoked_certs_from_s3_skips_unknown_serial_among_valid_entries(mock_s3_download, mock_db_get_cert):
-    """Unknown serial entries are skipped without affecting the rest of the revoked list."""
+def test_list_revoked_certs_from_s3_skips_unknown_serial_among_valid_entries(
+    mock_s3_download, mock_db_get_cert, mock_db_revocation_date, mock_crypto_revoked_cert
+):
+    """Unknown serial entries are skipped; valid entries are still included in the revoked list."""
     revoked_json = [
+        {"common_name": "valid.example.com", "serial_number": "111111111111"},
         {"common_name": "unknown.example.com", "serial_number": "000000000000"},
     ]
 
     mock_s3_download.side_effect = lambda *a, **kw: _make_s3_response(revoked_json)
-    mock_db_get_cert.return_value = None
+
+    # First call returns a valid (already-revoked) cert; second call returns None.
+    valid_cert_item = {
+        "CommonName": {"S": "valid.example.com"},
+        "SerialNumber": {"S": "111111111111"},
+        "Revoked": {"S": "2026-01-01 00:00:00"},
+    }
+    mock_db_get_cert.side_effect = [valid_cert_item, None]
+    mock_db_revocation_date.return_value = datetime.datetime(2026, 1, 1)
+    mock_crypto_revoked_cert.return_value = MagicMock()
 
     revoked_certs, newly_revoked_details = list_revoked_certs_from_s3(
         "test-project", "dev", "external-bucket", "internal-bucket"
     )
 
-    assert not revoked_certs
+    assert len(revoked_certs) == 1
     assert not newly_revoked_details
 
 

--- a/modules/terraform-aws-ca-lambda/utils/certs/db.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/db.py
@@ -153,7 +153,7 @@ def db_update_crl_number(project, env_name, common_name, serial_number):
 
 
 def db_get_certificate(project, env_name, common_name, serial_number):
-    """returns certificate with specified serial_number"""
+    """Returns the certificate item for the given serial_number, or None if not found."""
     client = boto3.client("dynamodb")
 
     table_name = db_get_table_name(project, env_name)
@@ -169,7 +169,6 @@ def db_get_certificate(project, env_name, common_name, serial_number):
 
     matches = [i for i in items if i["SerialNumber"]["S"] == serial_number]
     if not matches:
-        print(f"certificate with serial number {serial_number} not found in database for {common_name}")
         return None
     return matches[0]
 

--- a/modules/terraform-aws-ca-lambda/utils/certs/db.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/db.py
@@ -167,7 +167,11 @@ def db_get_certificate(project, env_name, common_name, serial_number):
     )
     items = response["Items"]
 
-    return [i for i in items if i["SerialNumber"]["S"] == serial_number][0]
+    matches = [i for i in items if i["SerialNumber"]["S"] == serial_number]
+    if not matches:
+        print(f"certificate with serial number {serial_number} not found in database for {common_name}")
+        return None
+    return matches[0]
 
 
 def db_revocation_date(project, env_name, common_name, serial_number):


### PR DESCRIPTION
fixes https://github.com/serverless-ca/terraform-aws-ca/issues/590