### PR TITLE
fix: KMS digest signing to support file size > 4096 bytes

### DIFF
--- a/modules/terraform-aws-ca-lambda/unittests/test_crypto_kms_classes.py
+++ b/modules/terraform-aws-ca-lambda/unittests/test_crypto_kms_classes.py
@@ -12,17 +12,19 @@ import hashlib
 from unittest.mock import MagicMock, patch
 
 import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, padding
 
 from utils.certs.crypto_kms_classes import AWSKMSEllipticCurvePrivateKey, AWSKMSRSAPrivateKey
 
 # A payload comfortably larger than the 4096-byte KMS RAW limit (the regression case).
 LARGE_PAYLOAD = b"a" * 5000
 
-# hash_algorithm -> (KMS SigningAlgorithm, expected digest length in bytes)
+# hash_algorithm -> (KMS SigningAlgorithm, expected digest length in bytes, hash class)
 ECDSA_VARIANTS = {
-    "sha256": ("ECDSA_SHA_256", 32),
-    "sha384": ("ECDSA_SHA_384", 48),
-    "sha512": ("ECDSA_SHA_512", 64),
+    "sha256": ("ECDSA_SHA_256", 32, hashes.SHA256),
+    "sha384": ("ECDSA_SHA_384", 48, hashes.SHA384),
+    "sha512": ("ECDSA_SHA_512", 64, hashes.SHA512),
 }
 
 
@@ -30,7 +32,7 @@ ECDSA_VARIANTS = {
 @patch("utils.certs.crypto_kms_classes.boto3")
 def test_ec_sign_uses_digest_message_type(mock_boto3, hash_algorithm, expected):
     """EC sign hashes locally and signs the digest with MessageType=DIGEST for every curve."""
-    signing_algorithm, digest_len = expected
+    signing_algorithm, digest_len, hash_class = expected
 
     mock_client = MagicMock()
     mock_client.sign.return_value = {"Signature": b"signature"}
@@ -38,7 +40,8 @@ def test_ec_sign_uses_digest_message_type(mock_boto3, hash_algorithm, expected):
 
     private_key = AWSKMSEllipticCurvePrivateKey("test-key-id", hash_algorithm)
 
-    signature = private_key.sign(LARGE_PAYLOAD, MagicMock())
+    # Use a real cryptography signature algorithm, as x509 signing does in production.
+    signature = private_key.sign(LARGE_PAYLOAD, ec.ECDSA(hash_class()))
 
     assert signature == b"signature"
     mock_client.sign.assert_called_once()
@@ -63,7 +66,8 @@ def test_rsa_sign_uses_digest_message_type(mock_boto3):
 
     private_key = AWSKMSRSAPrivateKey("test-key-id")
 
-    signature = private_key.sign(LARGE_PAYLOAD, MagicMock(), MagicMock())
+    # Use real cryptography padding/hash objects, as x509 signing does in production.
+    signature = private_key.sign(LARGE_PAYLOAD, padding.PKCS1v15(), hashes.SHA256())
 
     assert signature == b"signature"
     mock_client.sign.assert_called_once()
@@ -86,4 +90,4 @@ def test_ec_sign_rejects_unknown_hash_algorithm(mock_boto3):
     private_key = AWSKMSEllipticCurvePrivateKey("test-key-id", "md5")
 
     with pytest.raises(NotImplementedError):
-        private_key.sign(LARGE_PAYLOAD, MagicMock())
+        private_key.sign(LARGE_PAYLOAD, ec.ECDSA(hashes.SHA256()))

--- a/modules/terraform-aws-ca-lambda/unittests/test_crypto_kms_classes.py
+++ b/modules/terraform-aws-ca-lambda/unittests/test_crypto_kms_classes.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for crypto_kms_classes.py — regression tests for issue #606.
+
+AWS KMS ``Sign`` rejects a RAW ``Message`` longer than 4096 bytes. The KMS-backed
+key classes therefore hash the data locally and sign the fixed-size digest with
+``MessageType="DIGEST"``. These tests assert that behaviour for both the RSA and
+the Elliptic Curve key classes, across every ECDSA key size the module supports
+(``ECC_NIST_P256``/``P384``/``P521``), including a payload larger than 4096 bytes.
+"""
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.certs.crypto_kms_classes import AWSKMSEllipticCurvePrivateKey, AWSKMSRSAPrivateKey
+
+# A payload comfortably larger than the 4096-byte KMS RAW limit (the regression case).
+LARGE_PAYLOAD = b"a" * 5000
+
+# hash_algorithm -> (KMS SigningAlgorithm, expected digest length in bytes)
+ECDSA_VARIANTS = {
+    "sha256": ("ECDSA_SHA_256", 32),
+    "sha384": ("ECDSA_SHA_384", 48),
+    "sha512": ("ECDSA_SHA_512", 64),
+}
+
+
+@pytest.mark.parametrize("hash_algorithm,expected", list(ECDSA_VARIANTS.items()))
+@patch("utils.certs.crypto_kms_classes.boto3")
+def test_ec_sign_uses_digest_message_type(mock_boto3, hash_algorithm, expected):
+    """EC sign hashes locally and signs the digest with MessageType=DIGEST for every curve."""
+    signing_algorithm, digest_len = expected
+
+    mock_client = MagicMock()
+    mock_client.sign.return_value = {"Signature": b"signature"}
+    mock_boto3.client.return_value = mock_client
+
+    private_key = AWSKMSEllipticCurvePrivateKey("test-key-id", hash_algorithm)
+
+    signature = private_key.sign(LARGE_PAYLOAD, MagicMock())
+
+    assert signature == b"signature"
+    mock_client.sign.assert_called_once()
+    _, kwargs = mock_client.sign.call_args
+    assert kwargs["MessageType"] == "DIGEST"
+    assert kwargs["SigningAlgorithm"] == signing_algorithm
+    assert kwargs["KeyId"] == "test-key-id"
+
+    expected_digest = hashlib.new(hash_algorithm, LARGE_PAYLOAD).digest()
+    assert kwargs["Message"] == expected_digest
+    # The digest is fixed-size and well within the 4096-byte KMS limit.
+    assert len(kwargs["Message"]) == digest_len
+    assert len(kwargs["Message"]) <= 4096
+
+
+@patch("utils.certs.crypto_kms_classes.boto3")
+def test_rsa_sign_uses_digest_message_type(mock_boto3):
+    """RSA sign hashes locally with sha256 and signs the digest with MessageType=DIGEST."""
+    mock_client = MagicMock()
+    mock_client.sign.return_value = {"Signature": b"signature"}
+    mock_boto3.client.return_value = mock_client
+
+    private_key = AWSKMSRSAPrivateKey("test-key-id")
+
+    signature = private_key.sign(LARGE_PAYLOAD, MagicMock(), MagicMock())
+
+    assert signature == b"signature"
+    mock_client.sign.assert_called_once()
+    _, kwargs = mock_client.sign.call_args
+    assert kwargs["MessageType"] == "DIGEST"
+    assert kwargs["SigningAlgorithm"] == "RSASSA_PKCS1_V1_5_SHA_256"
+    assert kwargs["KeyId"] == "test-key-id"
+
+    expected_digest = hashlib.sha256(LARGE_PAYLOAD).digest()
+    assert kwargs["Message"] == expected_digest
+    assert len(kwargs["Message"]) == 32
+    assert len(kwargs["Message"]) <= 4096
+
+
+@patch("utils.certs.crypto_kms_classes.boto3")
+def test_ec_sign_rejects_unknown_hash_algorithm(mock_boto3):
+    """An unsupported hash algorithm raises NotImplementedError before calling KMS."""
+    mock_boto3.client.return_value = MagicMock()
+
+    private_key = AWSKMSEllipticCurvePrivateKey("test-key-id", "md5")
+
+    with pytest.raises(NotImplementedError):
+        private_key.sign(LARGE_PAYLOAD, MagicMock())

--- a/modules/terraform-aws-ca-lambda/utils/certs/crypto_kms_classes.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/crypto_kms_classes.py
@@ -1,3 +1,4 @@
+import hashlib
 import boto3
 from cryptography.hazmat.primitives._asymmetric import AsymmetricPadding
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
@@ -61,7 +62,13 @@ class AWSKMSEllipticCurvePrivateKey(ec.EllipticCurvePrivateKey):
         except KeyError as exc:
             raise NotImplementedError(f"Unknown Signature Algorithm: {format(signature_algorithm.name)}") from exc
         client = boto3.client("kms")
-        sign_response = client.sign(KeyId=self.keyid, SigningAlgorithm=sig_alg_str, Message=data)
+        # KMS Sign limits a RAW message to 4096 bytes, so hash locally and sign
+        # the fixed-size digest (MessageType=DIGEST) to support larger payloads
+        # such as CRLs with many revoked certificates (issue #606).
+        digest = hashlib.new(self.hash_algorithm, data).digest()
+        sign_response = client.sign(
+            KeyId=self.keyid, SigningAlgorithm=sig_alg_str, Message=digest, MessageType="DIGEST"
+        )
 
         return sign_response["Signature"]
 
@@ -162,7 +169,13 @@ class AWSKMSRSAPrivateKey(rsa.RSAPrivateKey):
         except KeyError as exc:
             raise NotImplementedError(f"Unknown Signature Algorithm: {format(algorithm.name)}") from exc
         client = boto3.client("kms")
-        sign_response = client.sign(KeyId=self.keyid, SigningAlgorithm=sig_alg_str, Message=data)
+        # KMS Sign limits a RAW message to 4096 bytes, so hash locally and sign
+        # the fixed-size digest (MessageType=DIGEST) to support larger payloads
+        # such as CRLs with many revoked certificates (issue #606).
+        digest = hashlib.new(algorithm.name, data).digest()
+        sign_response = client.sign(
+            KeyId=self.keyid, SigningAlgorithm=sig_alg_str, Message=digest, MessageType="DIGEST"
+        )
 
         return sign_response["Signature"]
 

--- a/modules/terraform-aws-ca-lambda/utils/certs/kms.py
+++ b/modules/terraform-aws-ca-lambda/utils/certs/kms.py
@@ -33,11 +33,3 @@ def kms_get_public_key(kms_key_id):
     response = client.get_public_key(KeyId=kms_key_id)
 
     return response["PublicKey"]
-
-
-def kms_sign(kms_key_id, message, signing_algorithm="RSASSA_PSS_SHA_256"):
-    """returns digital signature"""
-    client = boto3.client(service_name="kms")
-    response = client.sign(KeyId=kms_key_id, SigningAlgorithm=signing_algorithm, Message=message)
-
-    return response["Signature"]


### PR DESCRIPTION
fixes https://github.com/serverless-ca/terraform-aws-ca/issues/606

**Root cause:** AWS KMS Sign with the default MessageType=RAW caps the Message parameter at 4096 bytes. The KMS-backed key classes passed the full to-be-signed bytes as RAW, so a CRL with enough revoked certificates exceeded the limit and failed.

**Changes**

1. `modules/terraform-aws-ca-lambda/utils/certs/crypto_kms_classes.py` — both sign methods (`AWSKMSEllipticCurvePrivateKey` `AWSKMSRSAPrivateKey`) now hash locally and sign the fixed-size digest with `MessageType="DIGEST"`. Added import `hashlib`.
    - EC uses self.hash_algorithm, so it's correct for all ECDSA key specs: ECC_NIST_P256→sha256, P384→sha384, P521→sha512.
    - RSA uses sha256, matching the existing RSASSA_PKCS1_V1_5_SHA_256 selection
2. `modules/terraform-aws-ca-lambda/utils/certs/kms.py` — removed the unused `kms_sign` function (dead code, no callers).
3. `modules/terraform-aws-ca-lambda/unittests/test_crypto_kms_classes.py` (new) — regression tests mocking KMS, parametrised across all 3 ECDSA curves + RSA, using a >4096-byte payload to prove the original failure case now works.