### PR TITLE
Replace certvalidator/oscrypto with python cryptography, extend to ML-DSA

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Pytest
         run: |
-          pytest -v modules/terraform-aws-ca-lambda      
+          pytest -v modules/terraform-aws-ca-lambda tests/test_certificate_validation.py
     
       - name: Black
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,7 +38,13 @@ jobs:
 
       - name: Pytest
         run: |
-          pytest -v modules/terraform-aws-ca-lambda tests/test_certificate_validation.py
+          pytest -v modules/terraform-aws-ca-lambda
+
+      # run separately as the lambda module's utils package shadows
+      # the top-level utils package within a single pytest process
+      - name: Pytest certificate validation
+        run: |
+          pytest -v tests/test_certificate_validation.py
     
       - name: Black
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,9 @@
 -r requirements-docs.txt
 aiohttp==3.14.3
-asn1crypto==1.5.1
 assertpy==1.1
 bandit==1.9.4
 black==26.5.1
 boto3==1.43.63
-certvalidator==0.11.1
 cryptography==50.0.0
 dataclasses-json==0.6.7
 prospector==1.19.1
@@ -14,6 +12,3 @@ requests==2.34.2
 slack-sdk==3.43.0
 structlog==26.1.0
 validators==0.35.0
-
-# TODO: Used by certvalidator - remove once latest oscrypto published to pypi
-oscrypto @ git+https://github.com/wbond/oscrypto.git@d5f3437ed24257895ae1edd9e503cfb352e635a8

--- a/tests/test_certificate_validation.py
+++ b/tests/test_certificate_validation.py
@@ -1,0 +1,317 @@
+"""
+Local unit tests for certificate chain validation in utils.modules.certs.crypto.
+
+These tests build CA hierarchies in memory with pyca/cryptography, so they run
+without a deployed CA or AWS credentials, and prove the validation code accepts
+RSA, ECDSA and ML-DSA (FIPS 204 post-quantum) certificate chains.
+"""
+
+import pytest
+from assertpy import assert_that
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.exceptions import UnsupportedAlgorithm
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import mldsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+import utils.modules.certs.crypto as certs_crypto
+from utils.modules.certs.crypto import (
+    InvalidCertificateError,
+    certificate_validated,
+    convert_truststore,
+    crypto_encode_private_key,
+    crypto_tls_cert_signing_request,
+    create_csr_info,
+    generate_key,
+)
+
+try:
+    mldsa.MLDSA44PrivateKey.generate()
+    ML_DSA_SUPPORTED = True
+except UnsupportedAlgorithm:
+    ML_DSA_SUPPORTED = False
+
+requires_ml_dsa = pytest.mark.skipif(not ML_DSA_SUPPORTED, reason="ML-DSA not supported by cryptography backend")
+
+CRL_DP_URL = "http://crl.example.com/issuing-ca.crl"
+
+PURPOSE_EKU_OIDS = {
+    "server_auth": ExtendedKeyUsageOID.SERVER_AUTH,
+    "client_auth": ExtendedKeyUsageOID.CLIENT_AUTH,
+}
+
+
+def _generate_key(algorithm):
+    if algorithm == "rsa":
+        return generate_key("rsa", 2048)
+    return generate_key(algorithm)
+
+
+def _sign(builder, key):
+    if isinstance(key, (mldsa.MLDSA44PrivateKey, mldsa.MLDSA65PrivateKey, mldsa.MLDSA87PrivateKey)):
+        return builder.sign(key, None)
+    return builder.sign(key, hashes.SHA256())
+
+
+def _subject(common_name):
+    return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+
+
+def _make_ca_certificate(common_name, key, issuer_cert=None, issuer_key=None, path_length=None):
+    """Self-signed root CA if no issuer is given, otherwise an issuing CA signed by the issuer"""
+    issuer_name = issuer_cert.subject if issuer_cert is not None else _subject(common_name)
+    signing_key = issuer_key if issuer_key is not None else key
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(_subject(common_name))
+        .issuer_name(issuer_name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(minutes=5))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=30))
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=False)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                key_cert_sign=True,
+                crl_sign=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(x509.BasicConstraints(ca=True, path_length=path_length), critical=True)
+    )
+    if issuer_cert is not None:
+        builder = builder.add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(issuer_cert.public_key()), critical=False
+        )
+
+    return _sign(builder, signing_key)
+
+
+def _make_leaf_certificate(  # pylint:disable=too-many-arguments,too-many-positional-arguments
+    common_name,
+    key,
+    issuer_cert,
+    issuer_key,
+    purposes=("client_auth", "server_auth"),
+    key_encipherment=True,
+    crl_dp_url=None,
+    lifetime=timedelta(days=1),
+):
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(_subject(common_name))
+        .issuer_name(issuer_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(minutes=5))
+        .not_valid_after(datetime.now(timezone.utc) - timedelta(minutes=5) + lifetime)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                key_cert_sign=False,
+                crl_sign=False,
+                content_commitment=False,
+                key_encipherment=key_encipherment,
+                data_encipherment=False,
+                key_agreement=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(x509.ExtendedKeyUsage([PURPOSE_EKU_OIDS[p] for p in purposes]), critical=False)
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName("test.example.com")]), critical=False)
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=False)
+        .add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(issuer_cert.public_key()), critical=False)
+    )
+    if crl_dp_url is not None:
+        builder = builder.add_extension(
+            x509.CRLDistributionPoints(
+                [
+                    x509.DistributionPoint(
+                        full_name=[x509.UniformResourceIdentifier(crl_dp_url)],
+                        relative_name=None,
+                        reasons=None,
+                        crl_issuer=None,
+                    )
+                ]
+            ),
+            critical=False,
+        )
+
+    return _sign(builder, issuer_key)
+
+
+def _make_crl(issuer_cert, issuer_key, revoked_serials=()):
+    builder = (
+        x509.CertificateRevocationListBuilder()
+        .issuer_name(issuer_cert.subject)
+        .last_update(datetime.now(timezone.utc) - timedelta(minutes=5))
+        .next_update(datetime.now(timezone.utc) + timedelta(days=1))
+    )
+    for serial in revoked_serials:
+        builder = builder.add_revoked_certificate(
+            x509.RevokedCertificateBuilder()
+            .serial_number(serial)
+            .revocation_date(datetime.now(timezone.utc) - timedelta(minutes=5))
+            .build()
+        )
+
+    return _sign(builder, issuer_key)
+
+
+def _make_chain(
+    root_algorithm, issuing_algorithm=None, leaf_algorithm=None, purposes=("client_auth", "server_auth"), **leaf_kwargs
+):
+    """Build root CA, issuing CA and leaf certificate; return leaf bundle PEM, chain objects and keys"""
+    issuing_algorithm = issuing_algorithm or root_algorithm
+    leaf_algorithm = leaf_algorithm or issuing_algorithm
+
+    root_key = _generate_key(root_algorithm)
+    issuing_key = _generate_key(issuing_algorithm)
+    leaf_key = _generate_key(leaf_algorithm)
+
+    root_cert = _make_ca_certificate("Test Root CA", root_key, path_length=1)
+    issuing_cert = _make_ca_certificate("Test Issuing CA", issuing_key, root_cert, root_key, path_length=0)
+    leaf_cert = _make_leaf_certificate("test.example.com", leaf_key, issuing_cert, issuing_key, purposes, **leaf_kwargs)
+
+    bundle_pem = b"".join(
+        cert.public_bytes(serialization.Encoding.PEM) for cert in (leaf_cert, issuing_cert, root_cert)
+    ).decode("utf-8")
+
+    return bundle_pem, leaf_cert, issuing_cert, issuing_key
+
+
+CHAIN_ALGORITHMS = [
+    pytest.param("ecdsa", id="ecdsa"),
+    pytest.param("rsa", id="rsa"),
+    pytest.param("ml-dsa-44", id="ml-dsa-44", marks=requires_ml_dsa),
+    pytest.param("ml-dsa-65", id="ml-dsa-65", marks=requires_ml_dsa),
+    pytest.param("ml-dsa-87", id="ml-dsa-87", marks=requires_ml_dsa),
+]
+
+
+@pytest.mark.parametrize("algorithm", CHAIN_ALGORITHMS)
+def test_certificate_validated(algorithm):
+    bundle_pem, _, _, _ = _make_chain(algorithm)
+    trust_roots = convert_truststore(bundle_pem)
+
+    assert_that(certificate_validated(bundle_pem, trust_roots, check_crl=False)).is_true()
+
+
+@requires_ml_dsa
+def test_certificate_validated_mixed_ml_dsa_chain():
+    """ML-DSA-65 root CA, ML-DSA-44 issuing CA and classical EC subject key, per the PQC plan scope"""
+    bundle_pem, _, _, _ = _make_chain("ml-dsa-65", issuing_algorithm="ml-dsa-44", leaf_algorithm="ecdsa")
+    trust_roots = convert_truststore(bundle_pem)
+
+    assert_that(certificate_validated(bundle_pem, trust_roots, check_crl=False)).is_true()
+
+
+@pytest.mark.parametrize("algorithm", CHAIN_ALGORITHMS)
+def test_certificate_not_valid_for_purpose(algorithm):
+    bundle_pem, _, _, _ = _make_chain(algorithm, purposes=("server_auth",))
+    trust_roots = convert_truststore(bundle_pem)
+
+    assert_that(certificate_validated).raises(InvalidCertificateError).when_called_with(
+        bundle_pem, trust_roots, ["client_auth"], check_crl=False
+    ).is_equal_to("The X.509 certificate provided is not valid for the purpose of client auth")
+
+
+def test_certificate_untrusted_chain_rejected():
+    bundle_pem, _, _, _ = _make_chain("ecdsa")
+    other_bundle_pem, _, _, _ = _make_chain("ecdsa")
+    unrelated_trust_roots = convert_truststore(other_bundle_pem)
+
+    with pytest.raises(InvalidCertificateError, match="could not be validated"):
+        certificate_validated(bundle_pem, unrelated_trust_roots, check_crl=False)
+
+
+def test_expired_certificate_rejected():
+    bundle_pem, _, _, _ = _make_chain("ecdsa", lifetime=timedelta(minutes=1))
+    trust_roots = convert_truststore(bundle_pem)
+
+    with pytest.raises(InvalidCertificateError, match="could not be validated"):
+        certificate_validated(bundle_pem, trust_roots, check_crl=False)
+
+
+@pytest.mark.parametrize("algorithm", CHAIN_ALGORITHMS)
+def test_revoked_certificate_rejected(algorithm, monkeypatch):
+    bundle_pem, leaf_cert, issuing_cert, issuing_key = _make_chain(algorithm, crl_dp_url=CRL_DP_URL)
+    trust_roots = convert_truststore(bundle_pem)
+
+    crl = _make_crl(issuing_cert, issuing_key, revoked_serials=[leaf_cert.serial_number])
+    monkeypatch.setattr(certs_crypto, "_fetch_crl", lambda url: crl)
+
+    with pytest.raises(InvalidCertificateError, match="revoked"):
+        certificate_validated(bundle_pem, trust_roots)
+
+
+@pytest.mark.parametrize("algorithm", CHAIN_ALGORITHMS)
+def test_certificate_not_on_crl_validated(algorithm, monkeypatch):
+    bundle_pem, _, issuing_cert, issuing_key = _make_chain(algorithm, crl_dp_url=CRL_DP_URL)
+    trust_roots = convert_truststore(bundle_pem)
+
+    crl = _make_crl(issuing_cert, issuing_key)
+    monkeypatch.setattr(certs_crypto, "_fetch_crl", lambda url: crl)
+
+    assert_that(certificate_validated(bundle_pem, trust_roots)).is_true()
+
+
+def test_crl_with_invalid_signature_rejected(monkeypatch):
+    bundle_pem, _, issuing_cert, _ = _make_chain("ecdsa", crl_dp_url=CRL_DP_URL)
+    trust_roots = convert_truststore(bundle_pem)
+
+    # CRL signed by a key that isn't the issuing CA's
+    rogue_key = _generate_key("ecdsa")
+    crl = _make_crl(issuing_cert, rogue_key)
+    monkeypatch.setattr(certs_crypto, "_fetch_crl", lambda url: crl)
+
+    with pytest.raises(InvalidCertificateError, match="CRL signature verification failed"):
+        certificate_validated(bundle_pem, trust_roots)
+
+
+def test_unreachable_crl_hard_fails(monkeypatch):
+    bundle_pem, _, _, _ = _make_chain("ecdsa", crl_dp_url=CRL_DP_URL)
+    trust_roots = convert_truststore(bundle_pem)
+
+    def _unreachable(url):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(certs_crypto, "_fetch_crl", _unreachable)
+
+    with pytest.raises(InvalidCertificateError, match="Unable to retrieve CRL"):
+        certificate_validated(bundle_pem, trust_roots)
+
+
+@requires_ml_dsa
+@pytest.mark.parametrize("algorithm", ["ml-dsa-44", "ml-dsa-65", "ml-dsa-87"])
+def test_ml_dsa_certificate_signing_request(algorithm):
+    private_key = generate_key(algorithm)
+    csr_info = create_csr_info("pqc-test.example.com")
+
+    csr_pem = crypto_tls_cert_signing_request(private_key, csr_info)
+    csr = x509.load_pem_x509_csr(csr_pem)
+
+    assert_that(csr.is_signature_valid).is_true()
+    assert_that(csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value).is_equal_to("pqc-test.example.com")
+
+
+@requires_ml_dsa
+def test_ml_dsa_private_key_encoding_round_trip():
+    private_key = generate_key("ml-dsa-65")
+
+    key_pem = crypto_encode_private_key(private_key)
+    reloaded = serialization.load_pem_private_key(key_pem, password=None)
+
+    assert_that(reloaded).is_instance_of(mldsa.MLDSA65PrivateKey)

--- a/tests/test_issued_certs.py
+++ b/tests/test_issued_certs.py
@@ -4,7 +4,6 @@ import json
 import pytest
 import structlog
 from datetime import timedelta
-from certvalidator.errors import InvalidCertificateError
 
 from cryptography.x509 import (
     DNSName,
@@ -26,6 +25,7 @@ from utils.modules.certs.crypto import (
     certificate_validated,
     convert_truststore,
     convert_pem_to_der,
+    InvalidCertificateError,
 )
 
 from utils.modules.aws.kms import get_kms_details

--- a/utils/modules/certs/crypto.py
+++ b/utils/modules/certs/crypto.py
@@ -1,16 +1,31 @@
-from asn1crypto import pem
+import urllib.request
+from datetime import datetime, timezone
+
 from cryptography import x509
-from cryptography.x509.oid import NameOID
+from cryptography.x509.oid import ExtendedKeyUsageOID, ExtensionOID, NameOID
+from cryptography.x509.verification import ExtensionPolicy, PolicyBuilder, Store, VerificationError
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa, ec
+from cryptography.hazmat.primitives.asymmetric import rsa, ec, mldsa
 from validators import domain as domain_validator
-from certvalidator import CertificateValidator, ValidationContext
+
+_CRL_FETCH_TIMEOUT_SECONDS = 30
+
+_ML_DSA_PRIVATE_KEY_TYPES = (mldsa.MLDSA44PrivateKey, mldsa.MLDSA65PrivateKey, mldsa.MLDSA87PrivateKey)
+
+_PURPOSE_EKU_OIDS = {
+    "server_auth": ExtendedKeyUsageOID.SERVER_AUTH,
+    "client_auth": ExtendedKeyUsageOID.CLIENT_AUTH,
+}
+
+
+class InvalidCertificateError(Exception):
+    """Certificate failed chain, purpose or revocation validation"""
 
 
 def convert_pem_to_der(pem_bytes: bytes):
     all_certs = []
-    for _, _, der_bytes in pem.unarmor(pem_bytes, multiple=True):
-        all_certs.append(der_bytes)
+    for cert in x509.load_pem_x509_certificates(pem_bytes):
+        all_certs.append(cert.public_bytes(serialization.Encoding.DER))
 
     return all_certs
 
@@ -25,21 +40,136 @@ def convert_truststore(cert_bundle: str):
     return trust_roots
 
 
+def _validate_purposes(certificate, purposes):
+    """Check Extended Key Usage of certificate includes all requested purposes"""
+    try:
+        extended_key_usages = list(certificate.extensions.get_extension_for_oid(ExtensionOID.EXTENDED_KEY_USAGE).value)
+    except x509.ExtensionNotFound:
+        extended_key_usages = []
+
+    invalid_purposes = [p for p in purposes if _PURPOSE_EKU_OIDS[p] not in extended_key_usages]
+    if invalid_purposes:
+        raise InvalidCertificateError(
+            "The X.509 certificate provided is not valid for the purpose of "
+            + ", ".join(p.replace("_", " ") for p in invalid_purposes)
+        )
+
+
+def _validate_key_usage(certificate):
+    """Check Key Usage of certificate includes digital signature and key encipherment"""
+    try:
+        key_usage = certificate.extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE).value
+    except x509.ExtensionNotFound as e:
+        raise InvalidCertificateError("The X.509 certificate provided has no keyUsage extension") from e
+
+    if not (key_usage.digital_signature and key_usage.key_encipherment):
+        raise InvalidCertificateError(
+            "The X.509 certificate provided is not valid for the purpose of digital signature, key encipherment"
+        )
+
+
+def _fetch_crl(url: str):
+    """Download and parse a CRL from an HTTP(S) CRL Distribution Point URL, in DER or PEM format"""
+    if not url.startswith(("http://", "https://")):
+        raise InvalidCertificateError(f"Unsupported CRL Distribution Point URL scheme: {url}")
+
+    with urllib.request.urlopen(url, timeout=_CRL_FETCH_TIMEOUT_SECONDS) as response:  # nosec B310 - scheme checked
+        crl_data = response.read()
+
+    try:
+        return x509.load_der_x509_crl(crl_data)
+    except ValueError:
+        return x509.load_pem_x509_crl(crl_data)
+
+
+def _crl_distribution_point_urls(certificate):
+    try:
+        distribution_points = certificate.extensions.get_extension_for_oid(ExtensionOID.CRL_DISTRIBUTION_POINTS).value
+    except x509.ExtensionNotFound:
+        return []
+
+    return [
+        general_name.value
+        for distribution_point in distribution_points
+        for general_name in distribution_point.full_name or []
+        if isinstance(general_name, x509.UniformResourceIdentifier)
+    ]
+
+
+def _validate_revocation(chain):
+    """Check revocation status of each certificate in the chain that publishes a CRL Distribution Point,
+    hard-failing if the CRL can't be retrieved or its signature can't be verified with the issuer's public key"""
+    for certificate, issuer in zip(chain, chain[1:]):
+        urls = _crl_distribution_point_urls(certificate)
+        if not urls:
+            continue
+
+        subject = certificate.subject.rfc4514_string()
+
+        crl = None
+        errors = []
+        for url in urls:
+            try:
+                crl = _fetch_crl(url)
+                break
+            except (OSError, ValueError) as e:
+                errors.append(f"{url}: {e}")
+        if crl is None:
+            raise InvalidCertificateError(f"Unable to retrieve CRL for certificate {subject}: {'; '.join(errors)}")
+
+        if not crl.is_signature_valid(issuer.public_key()):
+            raise InvalidCertificateError(f"CRL signature verification failed for certificate {subject}")
+
+        if crl.next_update_utc is not None and crl.next_update_utc < datetime.now(timezone.utc):
+            raise InvalidCertificateError(f"CRL for certificate {subject} is expired")
+
+        if crl.get_revoked_certificate_by_serial_number(certificate.serial_number) is not None:
+            raise InvalidCertificateError(f"The X.509 certificate provided is revoked: {subject}")
+
+
 def certificate_validated(pem_cert, trust_roots, purposes=None, check_crl=True):
     """
-    Validate certificate
+    Validate certificate chain to a trusted root, purposes (Extended Key Usage), and optionally
+    revocation status via CRL, using cryptography.x509.verification.
+    Supports RSA, ECDSA and ML-DSA certificate chains.
+
+    pem_cert: PEM certificate, optionally bundled with its CA chain
+    trust_roots: list of trusted CA certificates in DER format
     """
     if purposes is None:
         purposes = ["server_auth", "client_auth"]
 
-    cert = pem_cert.encode(encoding="utf-8")
-    if check_crl:
-        cert_context = ValidationContext(allow_fetching=True, revocation_mode="hard-fail", trust_roots=trust_roots)
-    else:
-        cert_context = ValidationContext(trust_roots=trust_roots)
+    certs = x509.load_pem_x509_certificates(pem_cert.encode(encoding="utf-8"))
+    leaf = certs[0]
+    intermediates = certs[1:]
 
-    validator = CertificateValidator(cert, validation_context=cert_context)
-    validator.validate_usage({"digital_signature", "key_encipherment"}, set(purposes), True)
+    store = Store([x509.load_der_x509_certificate(der) for der in trust_roots])
+
+    # a client verifier is used for chain building with both client and server certificates, as unlike
+    # a server verifier it doesn't require a Subject Alternative Name matching an expected hostname.
+    # EKU purpose checks are applied to the leaf certificate separately below, so the extension
+    # policy is permissive; CA certificates are still validated against CA/B Forum guidelines
+    verifier = (
+        PolicyBuilder()
+        .store(store)
+        .extension_policies(
+            ca_policy=ExtensionPolicy.webpki_defaults_ca(),
+            ee_policy=ExtensionPolicy.permit_all(),
+        )
+        .build_client_verifier()
+    )
+
+    try:
+        chain = verifier.verify(leaf, intermediates).chain
+    except VerificationError as e:
+        raise InvalidCertificateError(f"The X.509 certificate provided could not be validated: {e}") from e
+
+    _validate_key_usage(leaf)
+    _validate_purposes(leaf, purposes)
+
+    if check_crl:
+        _validate_revocation(chain)
+
     return True
 
 
@@ -110,9 +240,22 @@ def build_x509_sans(sans):
 def crypto_tls_cert_signing_request(private_key, csr_info):
     subject = build_subject_dn(csr_info)
     csr = x509.CertificateSigningRequestBuilder().subject_name(x509.Name(subject))
-    csr = csr.sign(private_key, hashes.SHA256())
+
+    # ML-DSA keys sign without a separate hash algorithm
+    if isinstance(private_key, _ML_DSA_PRIVATE_KEY_TYPES):
+        csr = csr.sign(private_key, None)
+    else:
+        csr = csr.sign(private_key, hashes.SHA256())
 
     return csr.public_bytes(serialization.Encoding.PEM)
+
+
+def _private_key_format(key):
+    """ML-DSA private keys can only be serialized in PKCS8 format"""
+    if isinstance(key, _ML_DSA_PRIVATE_KEY_TYPES):
+        return serialization.PrivateFormat.PKCS8
+
+    return serialization.PrivateFormat.TraditionalOpenSSL
 
 
 def crypto_encode_private_key(key, passphrase=None):
@@ -125,7 +268,7 @@ def crypto_encode_private_key(key, passphrase=None):
 
     return key.private_bytes(
         encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        format=_private_key_format(key),
         encryption_algorithm=encryption_algorithm,
     )
 
@@ -147,16 +290,25 @@ def generate_key(algorithm="ecdsa", key_length=256):
             return ec.generate_private_key(ec.SECP521R1())
         raise ValueError(f"Unsupported key length: {key_length}")
 
+    if algorithm == "ml-dsa-44":
+        return mldsa.MLDSA44PrivateKey.generate()
+
+    if algorithm == "ml-dsa-65":
+        return mldsa.MLDSA65PrivateKey.generate()
+
+    if algorithm == "ml-dsa-87":
+        return mldsa.MLDSA87PrivateKey.generate()
+
     raise ValueError(f"Unsupported algorithm: {algorithm}")
 
 
 def write_key_to_disk(key, filepath):
-    """Write RSA key to disk"""
+    """Write private key to disk"""
     with open(filepath, "wb") as f:
         f.write(
             key.private_bytes(
                 encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                format=_private_key_format(key),
                 encryption_algorithm=serialization.NoEncryption(),
             )
         )

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,5 +1,3 @@
-asn1crypto==1.5.1
 boto3==1.43.63
-certvalidator==0.11.1
 cryptography==50.0.0
 validators==0.35.0


### PR DESCRIPTION
## Summary

Preparatory step for post-quantum cryptography support, per [development/plans/post-quantum-cryptography.md](https://github.com/serverless-ca/terraform-aws-ca/blob/main/development/plans/post-quantum-cryptography.md) §7 phase 1:

* **Chain validation migrated to `cryptography.x509.verification`** — `certificate_validated()` in `utils/modules/certs/crypto.py` now builds and verifies chains with pyca's verification API (CA certificates checked against CA/B Forum guidelines) instead of `certvalidator`/`oscrypto`, retiring the oscrypto git-pin workaround in `requirements-dev.txt`
* **CRL revocation checking preserved** — hard-fail semantics: for each certificate publishing a CRL Distribution Point, the CRL is fetched, its signature verified against the issuer public key, currency checked, and the serial number looked up
* **ML-DSA (FIPS 204) support in client utils** — `generate_key()` accepts `ml-dsa-44/65/87`, CSR signing passes `algorithm=None` for ML-DSA keys, private key encoding uses PKCS8 where required
* **Dependencies removed** — `certvalidator`, `oscrypto` and `asn1crypto` dropped from `requirements-dev.txt` and `utils/requirements.txt`; PEM→DER conversion now uses `cryptography` directly

## Tests

* New AWS-free unit tests (`tests/test_certificate_validation.py`, added to the Python tests workflow) build in-memory CA hierarchies and validate:
  * RSA, ECDSA and ML-DSA-44/65/87 chains, plus the mixed chain in the plan's scope (ML-DSA-65 root, ML-DSA-44 issuing CA, EC subject key)
  * purpose (EKU) rejection with the same error message contract as before
  * revoked certificate rejection, CRL signature failure, unreachable CRL hard fail, untrusted chain and expired certificate rejection
* Integration tests unchanged apart from importing `InvalidCertificateError` from `utils.modules.certs.crypto` instead of `certvalidator.errors`
* Locally: 29 new unit tests + 193 existing lambda unit tests pass; `black`, `bandit` and `prospector` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)