### PR TITLE
prevent silent boto3 retry of non-idempotent TLS cert Lambda invocations

### DIFF
--- a/utils/client-cert.py
+++ b/utils/client-cert.py
@@ -8,7 +8,7 @@ import boto3
 from cryptography.hazmat.primitives.serialization import load_der_private_key
 from modules.certs.crypto import create_csr_info, crypto_encode_private_key, crypto_tls_cert_signing_request
 from modules.certs.kms import kms_generate_key_pair, kms_get_kms_key_id
-from modules.aws.lambdas import get_lambda_name
+from modules.aws.lambdas import get_lambda_client, get_lambda_name
 
 # identify home directory and create certs subdirectory if needed
 homedir = os.path.expanduser("~")
@@ -103,7 +103,7 @@ def main():  # pylint:disable=too-many-locals,too-many-statements
 
     # Invoke TLS certificate Lambda function
     lambda_name = get_lambda_name("tls-cert", session=session)
-    client = session.client("lambda")
+    client = get_lambda_client(session)
     response = client.invoke(
         FunctionName=lambda_name,
         InvocationType="RequestResponse",

--- a/utils/generate-cert.py
+++ b/utils/generate-cert.py
@@ -9,7 +9,7 @@ import boto3
 from cryptography.hazmat.primitives.serialization import load_der_private_key
 from modules.certs.crypto import create_csr_info, crypto_encode_private_key, crypto_tls_cert_signing_request
 from modules.certs.kms import kms_generate_key_pair, kms_get_kms_key_id
-from modules.aws.lambdas import get_lambda_name
+from modules.aws.lambdas import get_lambda_client, get_lambda_name
 
 # identify home directory and create certs subdirectory if needed
 homedir = os.path.expanduser("~")
@@ -162,7 +162,7 @@ def invoke_lambda(session, request_payload_bytes, env_name):
     """
 
     lambda_name = get_lambda_name("tls-cert", env_name, session=session)
-    client = session.client("lambda")
+    client = get_lambda_client(session)
     response = client.invoke(
         FunctionName=lambda_name,
         InvocationType="RequestResponse",

--- a/utils/modules/aws/lambdas.py
+++ b/utils/modules/aws/lambdas.py
@@ -2,6 +2,24 @@ import boto3
 import json
 import os
 
+from botocore.config import Config
+
+# A synchronous Lambda invocation is not idempotent, so it must never be retried automatically.
+# The read timeout also needs to exceed the Lambda function's own timeout, so that a slow
+# invocation returns its real response rather than timing out client-side.
+INVOKE_CONFIG = Config(read_timeout=300, retries={"max_attempts": 0})
+
+
+def get_lambda_client(session=None):
+    """
+    Get a Lambda client configured for non-idempotent synchronous invocations
+    """
+
+    if session is None:
+        return boto3.client("lambda", config=INVOKE_CONFIG)
+
+    return session.client("lambda", config=INVOKE_CONFIG)
+
 
 def ca_project():
     """Optional project name filter, set the CA_PROJECT environment variable to target one
@@ -34,10 +52,7 @@ def invoke_lambda(function_name, json_data, session=None):
     Invoke TLS certificate Lambda function
     """
 
-    if session is None:
-        lambda_client = boto3.client("lambda")
-    else:
-        lambda_client = session.client("lambda")
+    lambda_client = get_lambda_client(session)
 
     response = lambda_client.invoke(
         FunctionName=function_name,

--- a/utils/server-cert.py
+++ b/utils/server-cert.py
@@ -8,7 +8,7 @@ import boto3
 from cryptography.hazmat.primitives.serialization import load_der_private_key
 from modules.certs.crypto import create_csr_info, crypto_encode_private_key, crypto_tls_cert_signing_request
 from modules.certs.kms import kms_generate_key_pair, kms_get_kms_key_id
-from modules.aws.lambdas import get_lambda_name
+from modules.aws.lambdas import get_lambda_client, get_lambda_name
 
 # identify home directory and create certs subdirectory if needed
 homedir = os.path.expanduser("~")
@@ -105,7 +105,7 @@ def main():  # pylint:disable=too-many-locals,too-many-statements
 
     # Invoke TLS certificate Lambda function
     lambda_name = get_lambda_name("tls-cert", session=session)
-    client = session.client("lambda")
+    client = get_lambda_client(session)
     response = client.invoke(
         FunctionName=lambda_name,
         InvocationType="RequestResponse",


### PR DESCRIPTION
Fixes #660

## Problem

Integration tests occasionally failed with `KeyError: 'CertificateInfo'`, because the TLS
certificate Lambda returned `{"error": "Private key has already been used for a certificate"}`.

Root cause (from CloudWatch logs): a slow invocation issued the certificate within ~2s but then
stalled in the post-issuance path, completing at ~64s. The boto3 Lambda client used botocore
defaults — 60s read timeout with automatic retries — so it timed out and silently re-invoked with
the identical CSR. The retry correctly hit the private-key-reuse guard and was rejected. The CA
behaved correctly at every step; the flake came from the SDK retrying a non-idempotent `Invoke`.

## Change

`utils/modules/aws/lambdas.py` gains a `get_lambda_client()` helper returning a Lambda client
configured with:

```python
Config(read_timeout=300, retries={"max_attempts": 0})

• the read timeout exceeds the Lambda function's own timeout, so a slow invocation returns its
real response instead of timing out client-side
• a non-idempotent synchronous  Invoke  is never silently retried

 invoke_lambda  and the client utilities that invoke the TLS certificate Lambda
( utils/client-cert.py ,  utils/server-cert.py ,  utils/generate-cert.py ) now use the helper.
 get_lambda_name  is unchanged —  list_functions  is idempotent and keeps default retry behaviour.

Testing

• verified the constructed client reports  read_timeout=300  and  total_max_attempts=1 , with and
without an explicit boto3 session
•  black --check --line-length 120  passes