### PR TITLE
Links to post-quantum cryptography blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * Serverless Certificate Authority typically $50 per year
 * [Equivalent cost using AWS Private CA around $10,000 per year](https://serverlessca.com/faq/#how-did-you-work-out-the-cost-comparison-with-aws-private-ca)
 * CA private keys stored in [FIPS 140-3 level 3 certified hardware](https://aws.amazon.com/about-aws/whats-new/2023/05/aws-kms-hsm-fips-security-level-3)
+* Supports [post-quantum cryptography](https://serverlessca.com/pqc/)
 * Published as a public [Terraform registry module](https://registry.terraform.io/modules/serverless-ca/ca/aws/latest)
 * 100% serverless:
 
@@ -42,6 +43,8 @@ Talk and demo on [YouTube](https://youtu.be/JJD2GrZxLq4)
 > 📖 [Revoking access to IAM Roles Anywhere using open-source private CA](https://medium.com/@paulschwarzenberger/revoking-access-to-iam-roles-anywhere-using-open-source-private-ca-47667cc92299)
 
 > 📖 [Amazon CloudFront origin mTLS with open-source serverless CA](https://medium.com/@paulschwarzenberger/amazon-cloudfront-origin-mtls-with-open-source-serverless-ca-66878107b1d5)
+
+> 📖 [Open-source post-quantum cryptography serverless CA](https://medium.com/@paulschwarzenberger/open-source-post-quantum-cryptography-serverless-ca-a44504da50ea)
 
 ## Sponsors
 This project is supported by [Q-Solution](https://www.q-solution.co.uk)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ description: Serverless CA in AWS with FIPS 140-3 level 3 CA key storage and cos
 * Serverless Certificate Authority typically $50 per year
 * [Equivalent cost using AWS Private CA around $10,000 per year](./faq.md#how-did-you-work-out-the-cost-comparison-with-aws-private-ca)
 * CA private keys stored in [FIPS 140-3 level 3 certified hardware](https://aws.amazon.com/about-aws/whats-new/2023/05/aws-kms-hsm-fips-security-level-3)
+* Supports [post-quantum cryptography](pqc.md)
 * Published as a public [Terraform registry module](https://registry.terraform.io/modules/serverless-ca/ca/aws/latest)
 * 100% serverless:
 
@@ -42,6 +43,8 @@ Talk and demo on [YouTube](https://youtu.be/JJD2GrZxLq4)
 > 📖 [Revoking access to IAM Roles Anywhere using open-source private CA](https://medium.com/@paulschwarzenberger/revoking-access-to-iam-roles-anywhere-using-open-source-private-ca-47667cc92299)
 
 > 📖 [Amazon CloudFront origin mTLS with open-source serverless CA](https://medium.com/@paulschwarzenberger/amazon-cloudfront-origin-mtls-with-open-source-serverless-ca-66878107b1d5)
+
+> 📖 [Open-source post-quantum cryptography serverless CA](https://medium.com/@paulschwarzenberger/open-source-post-quantum-cryptography-serverless-ca-a44504da50ea)
 
 ## Sponsors
 This project is supported by [Q-Solution](https://www.q-solution.co.uk)

--- a/docs/pqc.md
+++ b/docs/pqc.md
@@ -13,8 +13,7 @@ later" adversaries with future quantum computers.
 
 Choose the `ML_DSA_44`, `ML_DSA_65` or `ML_DSA_87` key spec for each CA independently
 via the `root_ca_key_spec` and `issuing_ca_key_spec` Terraform
-[variables](https://github.com/serverless-ca/terraform-aws-ca/blob/main/variables.tf),
-e.g. an `ML_DSA_65` root CA with an `ML_DSA_44` issuing CA:
+[variables](https://github.com/serverless-ca/terraform-aws-ca/blob/main/variables.tf):
 
 | Key spec | NIST security category | Public key | Signature |
 |----------|:----------------------:|:----------:|:---------:|


### PR DESCRIPTION
This pull request updates documentation to highlight new support for post-quantum cryptography (PQC) in the Serverless CA project. It adds references to PQC in feature lists and links to new resources describing the feature.

**Documentation updates for post-quantum cryptography:**

* Added "Supports post-quantum cryptography" to the feature list in both `README.md` and `docs/index.md`, with links to more information. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R14)
* Added a link to a new Medium article about the open-source post-quantum cryptography serverless CA in both `README.md` and `docs/index.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-R48) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R47-R48)

**Clarification in PQC configuration instructions:**

* Simplified the Terraform variable example in `docs/pqc.md` for configuring PQC key specs.